### PR TITLE
Wait for process completion after each test method.

### DIFF
--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -575,6 +575,11 @@ public class IntegrationTest {
     @Override
     public void close() {
       process().destroy();
+      try {
+        process().waitFor();
+      } catch (InterruptedException e) {
+        // Should not happen.
+      }
     }
   }
 


### PR DESCRIPTION
Otherwise we may get a BindException when the next test method runs,
since the previous process hasn't exited yet and is still listening
to the server port.