### PR TITLE
Keep ClassNotFoundException as cause when reporting function not found.

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/FunctionLoader.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/FunctionLoader.java
@@ -22,14 +22,17 @@ public class FunctionLoader<T extends CloudFunction> {
   private final String functionTarget;
   private final ClassLoader classLoader;
   private final FunctionSignatureMatcher<T> matcher;
+  private final ClassNotFoundException newStyleException;
 
   public FunctionLoader(
       String functionTarget,
       ClassLoader classLoader,
-      FunctionSignatureMatcher<T> matcher) {
+      FunctionSignatureMatcher<T> matcher,
+      ClassNotFoundException newStyleException) {
     this.functionTarget = functionTarget;
     this.classLoader = classLoader;
     this.matcher = matcher;
+    this.newStyleException = newStyleException;
   }
 
   /**
@@ -40,7 +43,7 @@ public class FunctionLoader<T extends CloudFunction> {
   public T loadUserFunction() throws Exception {
     int lastDotIndex = functionTarget.lastIndexOf(".");
     if (lastDotIndex == -1) {
-      throw new ClassNotFoundException(functionTarget);
+      throw newStyleException;
     }
     String targetClassName = functionTarget.substring(0, lastDotIndex);
     String targetMethodName = functionTarget.substring(lastDotIndex + 1);
@@ -50,7 +53,8 @@ public class FunctionLoader<T extends CloudFunction> {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(
           "Could not load either " + functionTarget + " (new form) or "
-              + targetClassName + " (old form)");
+              + targetClassName + " (old form)",
+          newStyleException);
     }
 
     Object targetInstance = targetClass.getDeclaredConstructor().newInstance();

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionTest.java
@@ -84,8 +84,11 @@ public class BackgroundFunctionTest {
     HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
     String fullTarget = "com.google.cloud.functions.invoker.BackgroundFunctionTest$" + target;
     FunctionLoader<BackgroundCloudFunction> loader =
-        new FunctionLoader<>(fullTarget, getClass().getClassLoader(),
-            new BackgroundFunctionSignatureMatcher());
+        new FunctionLoader<>(
+            fullTarget,
+            getClass().getClassLoader(),
+            new BackgroundFunctionSignatureMatcher(),
+            null);
     BackgroundCloudFunction function = loader.loadUserFunction();
     BackgroundFunctionExecutor executor = new BackgroundFunctionExecutor(function);
     Mockito.when(req.getReader())

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/HttpFunctionTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/HttpFunctionTest.java
@@ -45,7 +45,7 @@ public class HttpFunctionTest {
         "com.google.cloud.functions.invoker.HttpFunctionTest$HttpWriter.writeResponse";
     String requestData = "testData";
     FunctionLoader<HttpCloudFunction> loader = new FunctionLoader<>(
-        fullTarget, getClass().getClassLoader(), new HttpFunctionSignatureMatcher());
+        fullTarget, getClass().getClassLoader(), new HttpFunctionSignatureMatcher(), null);
     HttpCloudFunction function = loader.loadUserFunction();
     HttpFunctionExecutor executor = new HttpFunctionExecutor(function);
     Mockito.when(req.getParameter("data")).thenReturn(requestData);


### PR DESCRIPTION
The code is complicated by the support for legacy "ClassName.method" way of
specifying function targets, which we will delete when we delete java8 support
from GCF. Under the assumption that the user did mean to use the new form, we
remember what the ClassNotFoundException was that caused us to fail, and we
include that in the cause chain of the final exception. That way the user can
see a possible ExceptionInInitializerError or the like that might be the
underlying reason for the failure.