### PR TITLE
Fix multipart support for HTTP functions.

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -55,6 +55,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -284,7 +285,9 @@ public class Invoker {
           functionSignatureType);
       throw new RuntimeException(error);
     }
-    servletContextHandler.addServlet(new ServletHolder(servlet), "/*");
+    ServletHolder servletHolder = new ServletHolder(servlet);
+    servletHolder.getRegistration().setMultipartConfig(new MultipartConfigElement(""));
+    servletContextHandler.addServlet(servletHolder, "/*");
 
     server.start();
     logServerInfo();

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/Multipart.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/Multipart.java
@@ -1,0 +1,36 @@
+package com.google.cloud.functions.invoker.testfunctions;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpRequest.HttpPart;
+import com.google.cloud.functions.HttpResponse;
+import java.io.PrintWriter;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * A simple proof-of-concept function for multipart handling.
+ *
+ * {@code HttpFunctionTest} contains more detailed testing, but this function is part of the
+ * integration test that shows that we can indeed access the multipart API from a function.
+ */
+public class Multipart implements HttpFunction {
+  @Override
+  public void service(HttpRequest request, HttpResponse response) throws Exception {
+    response.setContentType("text/plain");
+    String contentType = request.getContentType().orElse("<unknown>");
+    if (!contentType.startsWith("multipart/form-data")) {
+      response.getWriter().write("Content-Type is " + contentType + " not multipart/form-data");
+      return;
+    }
+    PrintWriter writer = new PrintWriter(response.getWriter());
+    NavigableMap<String, HttpPart> parts = new TreeMap<>(request.getParts());
+    parts.forEach(
+        (name, contents) -> {
+          writer.printf(
+              "part %s type %s length %d\n",
+              name, contents.getContentType().get(), contents.getContentLength());
+        }
+    );
+  }
+}


### PR DESCRIPTION
Jetty requires a servlet to be configured explicitly before it will accept multipart input.