### PR TITLE
Correctly resolve function runtime classpath in Maven plugin. Fixes #30

### DIFF
--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
@@ -70,13 +70,6 @@ public class RunFunction extends AbstractMojo {
   @Parameter(property = "run.port", defaultValue = "8080")
   private Integer port;
 
-  /**
-   * Used to determine what classpath needs to be used to load the function. This parameter is
-   * injected by Maven and can't be set explicitly in a pom.xml file.
-   */
-  @Parameter(defaultValue = "${project.runtimeClasspathElements}", readonly = true, required = true)
-  private List<String> runtimePath;
-
   private final MavenSession mavenSession;
   private final MavenProject mavenProject;
   private final ProjectDependenciesResolver resolver;
@@ -110,7 +103,7 @@ public class RunFunction extends AbstractMojo {
       RepositorySystemSession session = mavenSession.getRepositorySession();
       DependencyResolutionRequest dependencyResolutionRequest = new DefaultDependencyResolutionRequest(mavenProject, session);
       dependencyResolutionRequest.setResolutionFilter(filter);
-    DependencyResolutionResult result = null;
+    DependencyResolutionResult result;
     try {
       result = resolver.resolve(dependencyResolutionRequest);
       List<Dependency> dependencies = result.getDependencies();

--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
@@ -4,7 +4,11 @@ import com.google.cloud.functions.invoker.runner.Invoker;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -12,6 +16,14 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.*;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+
+import javax.inject.Inject;
 
 /**
  * Runs a function using the Java Functions Framework. Typically this plugin is configured in one
@@ -44,6 +56,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Execute(phase = LifecyclePhase.COMPILE)
 public class RunFunction extends AbstractMojo {
 
+
   /**
    * The name of the function to run. This is the name of a class that implements one of the
    * interfaces in {@code com.google.cloud.functions}.
@@ -61,11 +74,22 @@ public class RunFunction extends AbstractMojo {
    * Used to determine what classpath needs to be used to load the function. This parameter is
    * injected by Maven and can't be set explicitly in a pom.xml file.
    */
-  @Parameter(defaultValue = "${project.compileClasspathElements}", readonly = true, required = true)
-  private List<String> compilePath;
+  @Parameter(defaultValue = "${project.runtimeClasspathElements}", readonly = true, required = true)
+  private List<String> runtimePath;
+
+  private final MavenSession mavenSession;
+  private final MavenProject mavenProject;
+  private final ProjectDependenciesResolver resolver;
+
+  @Inject
+  public RunFunction(MavenProject mavenProject, MavenSession mavenSession, ProjectDependenciesResolver resolver) {
+    this.mavenProject = mavenProject;
+    this.mavenSession = mavenSession;
+    this.resolver = resolver;
+  }
 
   public void execute() throws MojoExecutionException {
-    String classpath = String.join(File.pathSeparator, compilePath);
+    String classpath = resolveDependencies();
     List<String> args = new ArrayList<>();
     args.addAll(Arrays.asList("--classpath", classpath));
     if (functionTarget != null) {
@@ -78,5 +102,30 @@ public class RunFunction extends AbstractMojo {
       getLog().error("Could not invoke function: " + e, e);
       throw new MojoExecutionException("Could not invoke function", e);
     }
+  }
+
+
+  private String resolveDependencies() throws MojoExecutionException {
+      DependencyFilter filter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE, JavaScopes.RUNTIME);
+      RepositorySystemSession session = mavenSession.getRepositorySession();
+      DependencyResolutionRequest dependencyResolutionRequest = new DefaultDependencyResolutionRequest(mavenProject, session);
+      dependencyResolutionRequest.setResolutionFilter(filter);
+    DependencyResolutionResult result = null;
+    try {
+      result = resolver.resolve(dependencyResolutionRequest);
+      List<Dependency> dependencies = result.getDependencies();
+      return buildClasspath(dependencies);
+    } catch (DependencyResolutionException e) {
+      throw new MojoExecutionException("Error resolving runtime classpath: " + e.getMessage(), e );
+    }
+  }
+
+  private String buildClasspath(List<Dependency> dependencies) {
+    Comparator<Dependency> byGroupId = Comparator.comparing(d -> d.getArtifact().getGroupId());
+    Comparator<Dependency> byArtifactId = Comparator.comparing(d -> d.getArtifact().getArtifactId());
+    return dependencies.stream()
+            .sorted(byGroupId.thenComparing(byArtifactId))
+            .map(dependency -> dependency.getArtifact().getFile().getAbsolutePath())
+            .collect(Collectors.joining(File.pathSeparator));
   }
 }

--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
@@ -1,12 +1,10 @@
 package com.google.cloud.functions.plugin;
 
 import com.google.cloud.functions.invoker.runner.Invoker;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Execute;

--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
@@ -1,29 +1,14 @@
 package com.google.cloud.functions.plugin;
 
 import com.google.cloud.functions.invoker.runner.Invoker;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.*;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.*;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.util.artifact.JavaScopes;
-import org.eclipse.aether.util.filter.DependencyFilterUtils;
-
-import javax.inject.Inject;
 
 /**
  * Runs a function using the Java Functions Framework. Typically this plugin is configured in one
@@ -51,8 +36,8 @@ import javax.inject.Inject;
  */
 @Mojo(name = "run",
     defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
-    requiresDependencyResolution = ResolutionScope.COMPILE,
-    requiresDependencyCollection = ResolutionScope.COMPILE)
+    requiresDependencyResolution = ResolutionScope.RUNTIME,
+    requiresDependencyCollection = ResolutionScope.RUNTIME)
 @Execute(phase = LifecyclePhase.COMPILE)
 public class RunFunction extends AbstractMojo {
 
@@ -70,19 +55,15 @@ public class RunFunction extends AbstractMojo {
   @Parameter(property = "run.port", defaultValue = "8080")
   private Integer port;
 
-  private final MavenSession mavenSession;
-  private final MavenProject mavenProject;
-  private final ProjectDependenciesResolver resolver;
-
-  @Inject
-  public RunFunction(MavenProject mavenProject, MavenSession mavenSession, ProjectDependenciesResolver resolver) {
-    this.mavenProject = mavenProject;
-    this.mavenSession = mavenSession;
-    this.resolver = resolver;
-  }
+  /**
+   * Used to determine what classpath needs to be used to load the function. This parameter is
+   * injected by Maven and can't be set explicitly in a pom.xml file.
+   */
+  @Parameter(defaultValue = "${project.runtimeClasspathElements}", readonly = true, required = true)
+  private List<String> runtimePath;
 
   public void execute() throws MojoExecutionException {
-    String classpath = resolveDependencies();
+    String classpath = String.join(File.pathSeparator, runtimePath);
     List<String> args = new ArrayList<>();
     args.addAll(Arrays.asList("--classpath", classpath));
     if (functionTarget != null) {
@@ -98,27 +79,5 @@ public class RunFunction extends AbstractMojo {
   }
 
 
-  private String resolveDependencies() throws MojoExecutionException {
-      DependencyFilter filter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE, JavaScopes.RUNTIME);
-      RepositorySystemSession session = mavenSession.getRepositorySession();
-      DependencyResolutionRequest dependencyResolutionRequest = new DefaultDependencyResolutionRequest(mavenProject, session);
-      dependencyResolutionRequest.setResolutionFilter(filter);
-    DependencyResolutionResult result;
-    try {
-      result = resolver.resolve(dependencyResolutionRequest);
-      List<Dependency> dependencies = result.getDependencies();
-      return buildClasspath(dependencies);
-    } catch (DependencyResolutionException e) {
-      throw new MojoExecutionException("Error resolving runtime classpath: " + e.getMessage(), e );
-    }
-  }
 
-  private String buildClasspath(List<Dependency> dependencies) {
-    Comparator<Dependency> byGroupId = Comparator.comparing(d -> d.getArtifact().getGroupId());
-    Comparator<Dependency> byArtifactId = Comparator.comparing(d -> d.getArtifact().getArtifactId());
-    return dependencies.stream()
-            .sorted(byGroupId.thenComparing(byArtifactId))
-            .map(dependency -> dependency.getArtifact().getFile().getAbsolutePath())
-            .collect(Collectors.joining(File.pathSeparator));
-  }
 }

--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/RunFunction.java
@@ -1,14 +1,19 @@
 package com.google.cloud.functions.plugin;
 
 import com.google.cloud.functions.invoker.runner.Invoker;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.*;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Runs a function using the Java Functions Framework. Typically this plugin is configured in one
@@ -77,7 +82,4 @@ public class RunFunction extends AbstractMojo {
       throw new MojoExecutionException("Could not invoke function", e);
     }
   }
-
-
-
 }


### PR DESCRIPTION
This PR correctly builds the runtime classpath for the function. The current implementation only includes compile dependencies which is broken for all but the most trivial cases.