### PR TITLE
Use the command param env-vars-file instead of env-var-file.

### DIFF
--- a/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/DeployFunction.java
+++ b/invoker/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/DeployFunction.java
@@ -329,7 +329,7 @@ public class DeployFunction extends CloudSdkMojo {
       commands.add("--set-env-vars=" + mapJoiner.join(environmentVariables));
     }
     if (envVarsFile != null) {
-      commands.add("--env-var-file=" + envVarsFile);
+      commands.add("--env-vars-file=" + envVarsFile);
     }
     commands.add("--runtime=" + runtime);
 

--- a/invoker/function-maven-plugin/src/test/java/com/google/cloud/functions/plugin/DeployFunctionTest.java
+++ b/invoker/function-maven-plugin/src/test/java/com/google/cloud/functions/plugin/DeployFunctionTest.java
@@ -48,7 +48,7 @@ public class DeployFunctionTest {
             "--vpc-connector=a connector",
             "--max-instances=3",
             "--set-env-vars=env1=a,env2=b",
-            "--env-var-file=myfile",
+            "--env-vars-file=myfile",
             "--runtime=java11");
     assertThat(mojo.getCommands()).isEqualTo(expected);
   }


### PR DESCRIPTION
As defined in the [docs](https://cloud.google.com/functions/docs/env-var), the command should be  `--env-vars-file`instead of `--env-var-file` (note the `s`missing) 

Running the original code we just get Error: ` unrecognized arguments: --env-var-file=ci-env.yaml (did you mean '--env-vars-file'?)`

issue ref: #39 