### PR TITLE
ci: change to github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: Java CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build with Maven
+        run: (cd functions-framework-api/ && mvn install)
+      - name: Test
+        run: (cd invoker/ && mvn test)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-jdk:
-  - openjdk11
-script: (cd functions-framework-api/ && mvn install) && (cd invoker/ && mvn test)


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/functions-framework-java/issues/46.

Uses GitHub Actions for CI. We can now see logs within the PR.

![Screen Shot 2020-08-19 at 22 50 55](https://user-images.githubusercontent.com/744973/90714944-75de3c00-e26e-11ea-8d55-e33c768016b2.png)

