### PR TITLE
Update to Milestone 2 of the CloudEvents SDK.

### DIFF
--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-api</artifactId>
-      <version>2.0.0-milestone1</version>
+      <version>2.0.0-milestone2</version>
     </dependency>
   </dependencies>
 

--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -52,17 +52,17 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-api</artifactId>
-      <version>2.0.0-milestone1</version>
+      <version>2.0.0-milestone2</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-core</artifactId>
-      <version>2.0.0-milestone1</version>
+      <version>2.0.0-milestone2</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-json-jackson</artifactId>
-      <version>2.0.0-milestone1</version>
+      <version>2.0.0-milestone2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -15,7 +15,6 @@
 package com.google.cloud.functions.invoker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.cloud.functions.BackgroundFunction;
@@ -32,7 +31,7 @@ import io.cloudevents.core.message.impl.UnknownEncodingMessageReader;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -132,7 +131,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
   }
 
   private static Context contextFromCloudEvent(CloudEvent cloudEvent) {
-    ZonedDateTime timestamp = Optional.ofNullable(cloudEvent.getTime()).orElse(ZonedDateTime.now());
+    OffsetDateTime timestamp = Optional.ofNullable(cloudEvent.getTime()).orElse(OffsetDateTime.now());
     String timestampString = DateTimeFormatter.ISO_INSTANT.format(timestamp);
     // We don't have an obvious replacement for the Context.resource field, which with legacy events
     // corresponded to a value present for some proprietary Google event types.

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -51,8 +51,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -121,7 +121,7 @@ public class IntegrationTest {
         .withDataSchema(URI.create("/schema"))
         .withDataContentType("application/json")
         .withData(("{\"a\": 2, \"b\": 3, \"targetFile\": \"" + snoopFile + "\"}").getBytes(UTF_8))
-        .withTime(ZonedDateTime.of(2018, 4, 5, 17, 31, 0, 0, ZoneOffset.UTC))
+        .withTime(OffsetDateTime.of(2018, 4, 5, 17, 31, 0, 0, ZoneOffset.UTC))
         .build();
   }
 

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud.functions</groupId>
         <artifactId>functions-framework-api</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Temporarily switch the Functions Framework to use a SNAPSHOT version of the API.