### PR TITLE
docs: add ci and maven central badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Functions Framework for Java [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FGoogleCloudPlatform%2Ffunctions-framework-java%2Fbadge&style=flat)](https://actions-badge.atrox.dev/GoogleCloudPlatform/functions-framework-java/goto) [![Maven Central](https://img.shields.io/maven-central/v/com.google.cloud.functions/functions-framework-api.svg)](https://search.maven.org/search?q=com.google.cloud.functions:functions-framework-api&core=gav)
+# Functions Framework for Java [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FGoogleCloudPlatform%2Ffunctions-framework-java%2Fbadge&style=flat)](https://actions-badge.atrox.dev/GoogleCloudPlatform/functions-framework-java/goto) [![Maven Central](https://img.shields.io/maven-central/v/com.google.cloud.functions/functions-framework-api.svg)](https://search.maven.org/artifact/com.google.cloud.functions/functions-framework-api)
 
 An open source FaaS (Function as a service) framework for writing portable
 Java functions -- brought to you by the Google Cloud Functions team.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Functions Framework for Java [![Build Status](https://travis-ci.org/GoogleCloudPlatform/functions-framework-java.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/functions-framework-java)
+# Functions Framework for Java [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FGoogleCloudPlatform%2Ffunctions-framework-java%2Fbadge&style=flat)](https://actions-badge.atrox.dev/GoogleCloudPlatform/functions-framework-java/goto) [![Maven Central](https://img.shields.io/maven-central/v/com.google.cloud.functions/functions-framework-api.svg)](https://search.maven.org/search?q=com.google.cloud.functions:functions-framework-api&core=gav)
 
 An open source FaaS (Function as a service) framework for writing portable
 Java functions -- brought to you by the Google Cloud Functions team.


### PR DESCRIPTION
- Adds badges to README
  - Maven Central badge for main API
  - GitHub Actions badge

Similar to this repo: https://github.com/googleapis/google-cloud-java

Preview:

# Functions Framework for Java [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FGoogleCloudPlatform%2Ffunctions-framework-java%2Fbadge&style=flat)](https://actions-badge.atrox.dev/GoogleCloudPlatform/functions-framework-java/goto) [![Maven Central](https://img.shields.io/maven-central/v/com.google.cloud.functions/functions-framework-api.svg)](https://search.maven.org/artifact/com.google.cloud.functions/functions-framework-api)