### PR TITLE
Add more tests on the data of translated CloudEvents.

### DIFF
--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
@@ -143,7 +143,7 @@ public class GcfEventsTest {
     CloudEvent cloudEvent = GcfEvents.convertToCloudEvent(legacyEvent);
     Map<String, Object> data = cloudEventDataJson(cloudEvent);
     Map<?, ?> value = (Map<?, ?>) data.get("value");
-    Map<?, ?> fields = (Map<?, ?>)value.get("fields");
+    Map<?, ?> fields = (Map<?, ?>) value.get("fields");
     Map<String, Object> expectedFields = Map.of(
         "arrayValue", Map.of("arrayValue",
             Map.of("values",

--- a/invoker/core/src/test/resources/firestore_complex.json
+++ b/invoker/core/src/test/resources/firestore_complex.json
@@ -1,0 +1,81 @@
+{
+  "data": {
+    "oldValue": {},
+    "updateMask": {},
+    "value": {
+      "createTime": "2020-04-23T14:25:05.349632Z",
+      "fields": {
+        "arrayValue": {
+          "arrayValue": {
+            "values": [
+              {
+                "integerValue": "1"
+              },
+              {
+                "integerValue": "2"
+              }
+            ]
+          }
+        },
+        "booleanValue": {
+          "booleanValue": true
+        },
+        "doubleValue": {
+          "doubleValue": 5.5
+        },
+        "geoPointValue": {
+          "geoPointValue": {
+            "latitude": 51.4543,
+            "longitude": -0.9781
+          }
+        },
+        "intValue": {
+          "integerValue": "50"
+        },
+        "mapValue": {
+          "mapValue": {
+            "fields": {
+              "field1": {
+                "stringValue": "x"
+              },
+              "field2": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "stringValue": "x"
+                    },
+                    {
+                      "integerValue": "1"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "nullValue": {
+          "nullValue": null
+        },
+        "referenceValue": {
+          "referenceValue": "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"
+        },
+        "stringValue": {
+          "stringValue": "text"
+        },
+        "timestampValue": {
+          "timestampValue": "2020-04-23T14:23:53.241Z"
+        }
+      },
+      "name": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+      "updateTime": "2020-04-23T14:25:05.349632Z"
+    }
+  },
+  "eventId": "9babded5-e5f2-41af-a46a-06ba6bd84739-0",
+  "eventType": "providers/cloud.firestore/eventTypes/document.write",
+  "notSupported": {},
+  "params": {
+    "doc": "IH75dRdeYJKd4uuQiqch"
+  },
+  "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+  "timestamp": "2020-04-23T14:25:05.349632Z"
+}

--- a/invoker/core/src/test/resources/pubsub_binary.json
+++ b/invoker/core/src/test/resources/pubsub_binary.json
@@ -1,0 +1,16 @@
+﻿{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "data": "AQIDBA=="
+   }
+}


### PR DESCRIPTION
These tests check what is in the `data` field of the CloudEvents that we
translate from legacy events. For now they are not all that useful, because that
field is basically just a copy of the JSON payload of the legacy event. But we
do rearrange things slightly for PubSub events, and we are likely to do so for
Firebase events too in the future. Furthermore, if we eventually have a library
of classes representing the various event payloads, then we can use that library
instead of working with the JSON directly. That is what
google-cloudevents-dotnet does, for example.