### PR TITLE
fix: remove warnings from mvn install

### DIFF
--- a/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java
+++ b/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java
@@ -20,21 +20,29 @@ import java.util.Map;
 /** An interface for event function context. */
 public interface Context {
   /**
+   * Returns event ID.
+   * 
    * @return event ID
    */
   String eventId();
 
   /**
+   * Returns event timestamp.
+   * 
    * @return event timestamp
    */
   String timestamp();
 
   /**
+   * Returns event type.
+   * 
    * @return event type
    */
   String eventType();
 
   /**
+   * Returns event resource.
+   * 
    * @return event resource
    */
   String resource();

--- a/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java
+++ b/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java
@@ -19,16 +19,24 @@ import java.util.Map;
 
 /** An interface for event function context. */
 public interface Context {
-  /** Returns event ID. */
+  /**
+   * @return event ID
+   */
   String eventId();
 
-  /** Returns event timestamp. */
+  /**
+   * @return event timestamp
+   */
   String timestamp();
 
-  /** Returns event type. */
+  /**
+   * @return event type
+   */
   String eventType();
 
-  /** Returns event resource. */
+  /**
+   * @return event resource
+   */
   String resource();
 
   /**
@@ -42,6 +50,8 @@ public interface Context {
    * extension attributes</a>.
    *
    * <p>The map returned by this method may be empty but is never null.</p>
+   * 
+   * @return additional attributes form this event.
    */
   default Map<String, String> attributes() {
     return Collections.emptyMap();


### PR DESCRIPTION
Removes 5 warnings when running `mvn install`.

## Warnings

```
5 warnings
[WARNING] Javadoc Warnings
[WARNING] /Users/timmerman/Documents/github/googlecloudplatform/functions-framework-java/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java:23: warning: no @return
[WARNING] String eventId();
[WARNING] ^
[WARNING] /Users/timmerman/Documents/github/googlecloudplatform/functions-framework-java/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java:26: warning: no @return
[WARNING] String timestamp();
[WARNING] ^
[WARNING] /Users/timmerman/Documents/github/googlecloudplatform/functions-framework-java/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java:29: warning: no @return
[WARNING] String eventType();
[WARNING] ^
[WARNING] /Users/timmerman/Documents/github/googlecloudplatform/functions-framework-java/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java:32: warning: no @return
[WARNING] String resource();
[WARNING] ^
[WARNING] /Users/timmerman/Documents/github/googlecloudplatform/functions-framework-java/functions-framework-api/src/main/java/com/google/cloud/functions/Context.java:46: warning: no @return
[WARNING] default Map<String, String> attributes() {
[WARNING] ^
```

No issue filed.