### PR TITLE
ci: add lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,17 @@
+name: Java Lint CI
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+    - name: Lint Functions Framework API
+      run: (cd functions-framework-api/ && mvn clean verify -DskipTests -P lint)
+    - name: Lint Invoker
+      run: (cd invoker/ && mvn clean verify -DskipTests -P lint)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
+      with:
+        java-version: 11.x
     - name: Lint Functions Framework API
       run: (cd functions-framework-api/ && mvn clean verify -DskipTests -P lint)
     - name: Lint Invoker

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11.x
+    - name: Build API with Maven
+      run: (cd functions-framework-api/ && mvn install)
     - name: Lint Functions Framework API
       run: (cd functions-framework-api/ && mvn clean verify -DskipTests -P lint)
+    - name: Build Invoker with Maven
+      run: (cd functions-framework-api/ && mvn install)
     - name: Lint Invoker
       run: (cd invoker/ && mvn clean verify -DskipTests -P lint)


### PR DESCRIPTION
- Adds a basic linting workflow.
  - Uses same command as [Java Docs Samples](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/47a7c67b0cd25ad9b23d61335681d75a72877c16/SAMPLE_FORMAT.md#linting)

To be included with https://github.com/GoogleCloudPlatform/functions-framework#languages--test-status matrix