### PR TITLE
Added "hook" for server start event

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -284,7 +284,7 @@ public class Invoker {
 
     server.start();
     if (onServerStarted != null) {
-      onServerStarted();
+      onServerStarted.run();
     }
     
     logServerInfo();

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -209,6 +209,7 @@ public class Invoker {
   private final String functionTarget;
   private final String functionSignatureType;
   private final ClassLoader functionClassLoader;
+  private final Runnable onServerStarted;
 
   public Invoker(
       Integer port,
@@ -219,8 +220,22 @@ public class Invoker {
     this.functionTarget = functionTarget;
     this.functionSignatureType = functionSignatureType;
     this.functionClassLoader = functionClassLoader;
+    this.onServerStarted = null;
   }
 
+  public Invoker(
+      Integer port,
+      String functionTarget,
+      String functionSignatureType,
+      ClassLoader functionClassLoader,
+      Runnable onServerStarted) {
+    this.port = port;
+    this.functionTarget = functionTarget;
+    this.functionSignatureType = functionSignatureType;
+    this.functionClassLoader = functionClassLoader;
+    this.onServerStarted = onServerStarted;
+  }
+  
   Integer getPort() {
     return port;
   }
@@ -235,6 +250,10 @@ public class Invoker {
 
   ClassLoader getFunctionClassLoader() {
     return functionClassLoader;
+  }
+  
+  Runnable onServerStarted() {
+    return onServerStarted;
   }
 
   public void startServer() throws Exception {
@@ -264,6 +283,10 @@ public class Invoker {
     servletContextHandler.addServlet(servletHolder, "/*");
 
     server.start();
+    if (onServerStarted != null) {
+      onServerStarted();
+    }
+    
     logServerInfo();
     server.join();
   }

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -252,7 +252,7 @@ public class Invoker {
     return functionClassLoader;
   }
   
-  Runnable onServerStarted() {
+  Runnable getOnServerStarted() {
     return onServerStarted;
   }
 


### PR DESCRIPTION
This allows tests to detect when server starts.
Tests will execute faster than polling.
Avoids exposing the server instance.
Should have zero impact on existing usages