### PR TITLE
Update the version of the CloudEvents SDK to 2.0.0RC2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ properties
 
 # IDE
 .vscode/
+/invoker/target/

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-api</artifactId>
-      <version>2.0.0-milestone4</version>
+      <version>2.0.0.RC2</version>
     </dependency>
   </dependencies>
 

--- a/functions-framework-api/src/main/java/com/google/cloud/functions/CloudEventsFunction.java
+++ b/functions-framework-api/src/main/java/com/google/cloud/functions/CloudEventsFunction.java
@@ -4,12 +4,9 @@ import io.cloudevents.CloudEvent;
 
 /**
  * Represents a Cloud Function that is activated by an event and parsed into a {@link CloudEvent} object.
- * Because the {@link CloudEvent} API is not yet stable, a function implemented using this class may not
- * build or work correctly with later versions of that API. Once the API is stable, this interface will
- * become {@code CloudEventsFunction} and will also be stable.
  */
 @FunctionalInterface
-public interface ExperimentalCloudEventsFunction {
+public interface CloudEventsFunction {
   /**
    * Called to service an incoming event. This interface is implemented by user code to
    * provide the action for a given background function. If this method throws any exception

--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -52,17 +52,17 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-core</artifactId>
-      <version>2.0.0-milestone4</version>
+      <version>2.0.0.RC2</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-http-basic</artifactId>
-      <version>2.0.0-milestone4</version>
+      <version>2.0.0.RC2</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-json-jackson</artifactId>
-      <version>2.0.0-milestone4</version>
+      <version>2.0.0.RC2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toMap;
 
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
-import com.google.cloud.functions.ExperimentalCloudEventsFunction;
 import com.google.cloud.functions.RawBackgroundFunction;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -46,6 +45,7 @@ import java.util.logging.Logger;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.cloud.functions.CloudEventsFunction;
 
 /** Executes the user's background function. */
 public final class BackgroundFunctionExecutor extends HttpServlet {
@@ -60,7 +60,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
   private enum FunctionKind {
     BACKGROUND(BackgroundFunction.class),
     RAW_BACKGROUND(RawBackgroundFunction.class),
-    CLOUD_EVENTS(ExperimentalCloudEventsFunction.class);
+    CLOUD_EVENTS(CloudEventsFunction.class);
 
     static final List<FunctionKind> VALUES = Arrays.asList(values());
 
@@ -79,7 +79,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
   /**
    * Optionally makes a {@link BackgroundFunctionExecutor} for the given class, if it implements one
    * of {@link BackgroundFunction}, {@link RawBackgroundFunction}, or
-   * {@link ExperimentalCloudEventsFunction}. Otherwise returns {@link Optional#empty()}.
+   * {@link CloudEventsFunction}. Otherwise returns {@link Optional#empty()}.
    *
    * @param functionClass the class of a possible background function implementation.
    * @throws RuntimeException if the given class does implement one of the required interfaces, but we are
@@ -98,7 +98,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
    *
    * @throws RuntimeException if either the class does not implement one of
    *    {@link BackgroundFunction}, {@link RawBackgroundFunction}, or
-   *    {@link ExperimentalCloudEventsFunction}; or we are unable to construct an instance using its no-arg
+   *    {@link CloudEventsFunction}; or we are unable to construct an instance using its no-arg
    *     constructor.
    */
   public static BackgroundFunctionExecutor forClass(Class<?> functionClass) {
@@ -143,7 +143,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
         executor = new TypedFunctionExecutor<>(maybeTargetType.get(), backgroundFunction);
         break;
       case CLOUD_EVENTS:
-        executor = new CloudEventFunctionExecutor((ExperimentalCloudEventsFunction) instance);
+        executor = new CloudEventFunctionExecutor((CloudEventsFunction) instance);
         break;
       default: // can't happen, we've listed all the FunctionKind values already.
         throw new AssertionError(functionKind);
@@ -299,9 +299,9 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
   }
 
   private static class CloudEventFunctionExecutor extends FunctionExecutor<Void> {
-    private final ExperimentalCloudEventsFunction function;
+    private final CloudEventsFunction function;
 
-    CloudEventFunctionExecutor(ExperimentalCloudEventsFunction function) {
+    CloudEventFunctionExecutor(CloudEventsFunction function) {
       super(function.getClass());
       this.function = function;
     }

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/CloudEventSnoop.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/CloudEventSnoop.java
@@ -2,7 +2,6 @@ package com.google.cloud.functions.invoker.testfunctions;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.cloud.functions.ExperimentalCloudEventsFunction;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.cloudevents.CloudEvent;
@@ -10,8 +9,9 @@ import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
 import java.io.FileOutputStream;
+import com.google.cloud.functions.CloudEventsFunction;
 
-public class CloudEventSnoop implements ExperimentalCloudEventsFunction {
+public class CloudEventSnoop implements CloudEventsFunction {
   @Override
   public void accept(CloudEvent event) throws Exception {
     String payloadJson = new String(event.getData().toBytes(), UTF_8);

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud.functions</groupId>
         <artifactId>functions-framework-api</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Since the API is hopefully stable now, rename `ExperimentalCloudEventsFunction`
to `CloudEventsFunction`.

Add support for a `FUNCTION_SIGNATURE_TYPE` of `cloudevent`. Treat it the same
as `background`. (We don't really need `FUNCTION_SIGNATURE_TYPE`, since the
interface implemented by the function class tells us what the signature is.)

Simplify the integration test slightly by removing some intermediary helper
methods.