### PR TITLE
Define a property for the CloudEvents SDK version to avoid mentioning it three times.

### DIFF
--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -22,6 +22,7 @@
     <junit.jupiter.version>5.3.2</junit.jupiter.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <cloudevents.sdk.version>2.0.0.RC2</cloudevents.sdk.version>
   </properties>
 
   <licenses>
@@ -52,17 +53,17 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-core</artifactId>
-      <version>2.0.0.RC2</version>
+      <version>${cloudevents.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-http-basic</artifactId>
-      <version>2.0.0.RC2</version>
+      <version>${cloudevents.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-json-jackson</artifactId>
-      <version>2.0.0.RC2</version>
+      <version>${cloudevents.sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.CloudEventsFunction;
 import com.google.cloud.functions.Context;
 import com.google.cloud.functions.RawBackgroundFunction;
 import com.google.gson.Gson;
@@ -45,7 +46,6 @@ import java.util.logging.Logger;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.cloud.functions.CloudEventsFunction;
 
 /** Executes the user's background function. */
 public final class BackgroundFunctionExecutor extends HttpServlet {

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/CloudEventSnoop.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/CloudEventSnoop.java
@@ -2,6 +2,7 @@ package com.google.cloud.functions.invoker.testfunctions;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.cloud.functions.CloudEventsFunction;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.cloudevents.CloudEvent;
@@ -9,7 +10,6 @@ import io.cloudevents.core.format.EventFormat;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.jackson.JsonFormat;
 import java.io.FileOutputStream;
-import com.google.cloud.functions.CloudEventsFunction;
 
 public class CloudEventSnoop implements CloudEventsFunction {
   @Override


### PR DESCRIPTION
Also fix the import order in a couple of source files.