### PR TITLE
Ignore all mvn target directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 *.tar.gz
 *.rar
 
+# Maven
+target/
+
 # Gradle
 .gradle
 .idea/
@@ -44,4 +47,3 @@ properties
 
 # IDE
 .vscode/
-/invoker/target/


### PR DESCRIPTION
Currently running `mvn install` or `mvn test` causes a bunch of untracked changes to show up in git. Adding `target/` to the root `.gitignore` will recursively ignore all mvn target directories.