### PR TITLE
Add conformance tests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -34,7 +34,7 @@ jobs:
       run: (cd invoker/ && mvn install)
     
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.8
       with:
         functionType: 'http'
         useBuildpacks: false
@@ -43,7 +43,7 @@ jobs:
         startDelay: 10
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.8
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,52 @@
+name: Java Conformance CI
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [
+          11.x
+          # 12.x,
+          # 13.x
+        ]
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.15'
+    
+    - name: Build API with Maven
+      run: (cd functions-framework-api/ && mvn install)
+
+    - name: Build invoker with Maven
+      run: (cd invoker/ && mvn install)
+    
+    - name: Run HTTP conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      with:
+        functionType: 'http'
+        useBuildpacks: false
+        validateMapping: false
+        cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.HttpConformanceFunction'"
+        startDelay: 10
+
+    - name: Run cloudevent conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      with:
+        functionType: 'cloudevent'
+        useBuildpacks: false
+        validateMapping: false
+        cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.CloudEventsConformanceFunction'"
+        startDelay: 10

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ properties
 
 # IDE
 .vscode/
+
+# Conformance testing
+function_output.json
+serverlog_stderr.txt
+serverlog_stdout.txt

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>java-function-invoker-parent</artifactId>
+    <groupId>com.google.cloud.functions.invoker</groupId>
+    <version>1.0.3-SNAPSHOT</version>
+  </parent>
+
+  <groupId>com.google.cloud.functions.invoker</groupId>
+  <artifactId>conformance</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>GCF Confromance Tests</name>
+  <description>
+    A GCF project used to validate conformance to the Functions Framework contract
+    using the Functions Framework Confromance tools.
+  </description>
+  <url>https://github.com/GoogleCloudPlatform/functions-framework-conformance</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud.functions</groupId>
+      <artifactId>functions-framework-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.google.cloud.functions</groupId>
+          <artifactId>function-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -14,14 +14,14 @@
   <name>GCF Confromance Tests</name>
   <description>
     A GCF project used to validate conformance to the Functions Framework contract
-    using the Functions Framework Confromance tools.
+    using the Functions Framework Conformance tools.
   </description>
   <url>https://github.com/GoogleCloudPlatform/functions-framework-conformance</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/CloudEventsConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/CloudEventsConformanceFunction.java
@@ -23,8 +23,7 @@ import com.google.gson.JsonObject;
 import io.cloudevents.CloudEvent;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This class is used by the Functions Framework Conformance Tools to validate
@@ -48,14 +47,8 @@ public class CloudEventsConformanceFunction implements CloudEventsFunction {
 
   @Override
   public void accept(CloudEvent event) throws Exception {
-    BufferedWriter writer = null;
-    try {
-      writer = new BufferedWriter(new FileWriter("function_output.json"));
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter("function_output.json"))) {
       writer.write(serialize(event));
-    } finally {
-      if (writer != null) {
-        writer.close();
-      }
     }
   }
 
@@ -72,9 +65,8 @@ public class CloudEventsConformanceFunction implements CloudEventsFunction {
     jsonEvent.addProperty("subject", event.getSubject());
     jsonEvent.addProperty("specversion", event.getSpecVersion().toString());
 
-    String time = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
-      .format(new Date(event.getTime().toInstant().toEpochMilli()));
-    jsonEvent.addProperty("time", time);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
+    jsonEvent.addProperty("time", event.getTime().format(formatter));
 
     String payloadJson = new String(event.getData().toBytes(), UTF_8);
     JsonObject jsonObject = new Gson().fromJson(payloadJson, JsonObject.class);

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/CloudEventsConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/CloudEventsConformanceFunction.java
@@ -1,0 +1,85 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.functions.conformance;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.cloud.functions.CloudEventsFunction;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import io.cloudevents.CloudEvent;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class is used by the Functions Framework Conformance Tools to validate
+ * the framework's Cloud Events API. It can be run with the following command:
+ *
+ * <pre>{@code
+ * $ functions-framework-conformance-client \
+ *   -cmd="mvn function:run -Drun.functionTarget=com.google.cloud.functions.conformance.CloudEventsConformanceFunction" \
+ *   -type=cloudevent \
+ *   -buildpacks=false \
+ *   -validate-mapping=false \
+ *   -start-delay=5
+ * }</pre>
+ */
+public class CloudEventsConformanceFunction implements CloudEventsFunction {
+
+  private static final Gson gson = new GsonBuilder()
+      .serializeNulls()
+      .setPrettyPrinting()
+      .create();
+
+  @Override
+  public void accept(CloudEvent event) throws Exception {
+    BufferedWriter writer = null;
+    try {
+      writer = new BufferedWriter(new FileWriter("function_output.json"));
+      writer.write(serialize(event));
+    } finally {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+  }
+
+  /**
+   * Create a structured JSON representation of a cloud event
+   */
+  private String serialize(CloudEvent event) {
+    JsonObject jsonEvent = new JsonObject();
+
+    jsonEvent.addProperty("id", event.getId());
+    jsonEvent.addProperty("source", event.getSource().toString());
+    jsonEvent.addProperty("type", event.getType());
+    jsonEvent.addProperty("datacontenttype", event.getDataContentType());
+    jsonEvent.addProperty("subject", event.getSubject());
+    jsonEvent.addProperty("specversion", event.getSpecVersion().toString());
+
+    String time = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+      .format(new Date(event.getTime().toInstant().toEpochMilli()));
+    jsonEvent.addProperty("time", time);
+
+    String payloadJson = new String(event.getData().toBytes(), UTF_8);
+    JsonObject jsonObject = new Gson().fromJson(payloadJson, JsonObject.class);
+    jsonEvent.add("data", jsonObject);
+
+    return gson.toJson(jsonEvent);
+  }
+}

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/HttpConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/HttpConformanceFunction.java
@@ -40,19 +40,11 @@ public class HttpConformanceFunction implements HttpFunction {
   @Override
   public void service(HttpRequest request, HttpResponse response)
       throws IOException {
-
-    final BufferedReader reader = request.getReader();
-    BufferedWriter writer = null;
-
-    try {
-      writer = new BufferedWriter(new FileWriter("function_output.json"));
+    try (BufferedReader reader = request.getReader();
+        BufferedWriter writer = new BufferedWriter(new FileWriter("function_output.json"))) {
       int c;
       while ((c = reader.read()) != -1) {
         writer.write(c);
-      }
-    } finally {
-      if (writer != null) {
-        writer.close();
       }
     }
   }

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/HttpConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/HttpConformanceFunction.java
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.functions.conformance;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * This class is used by the Functions Framework Conformance Tools to validate
+ * the framework's HTTP API. It can be run with the following command:
+ *
+ * <pre>{@code
+ * $ functions-framework-conformance-client \
+ *   -cmd="mvn function:run -Drun.functionTarget=com.google.cloud.functions.conformance.HttpConformanceFunction" \
+ *   -type=http \
+ *   -buildpacks=false \
+ *   -validate-mapping=false \
+ *   -start-delay=5
+ * }</pre>
+ */
+public class HttpConformanceFunction implements HttpFunction {
+
+  @Override
+  public void service(HttpRequest request, HttpResponse response)
+      throws IOException {
+
+    final BufferedReader reader = request.getReader();
+    BufferedWriter writer = null;
+
+    try {
+      writer = new BufferedWriter(new FileWriter("function_output.json"));
+      int c;
+      while ((c = reader.read()) != -1) {
+        writer.write(c);
+      }
+    } finally {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+  }
+}

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -28,6 +28,7 @@
     <module>core</module>
     <module>testfunction</module>
     <module>function-maven-plugin</module>
+    <module>conformance</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This commit adds a GCF project that can be used with the [Cloud Functions Conformance tools](https://github.com/GoogleCloudPlatform/functions-framework-conformance) to validate HTTP and CloudEvent functions. It also adds a Github workflow that runs conformance tests on all PRs and commits to master.