### PR TITLE
Bug fixes for cloud event conversion

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -47,6 +47,5 @@ jobs:
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
-        validateMapping: false
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.CloudEventsConformanceFunction'"
         startDelay: 10

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>functions-framework-api</artifactId>
-      <version>1.0.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>functions-framework-api</artifactId>
+      <version>1.0.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -42,6 +43,7 @@
         <plugin>
           <groupId>com.google.cloud.functions</groupId>
           <artifactId>function-maven-plugin</artifactId>
+          <version>0.9.8-SNAPSHOT</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
@@ -29,6 +29,7 @@ import java.io.StringReader;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Ignore;
@@ -51,11 +52,11 @@ public class GcfEventsTest {
     {"legacy_pubsub.json", "google.cloud.pubsub.topic.v1.messagePublished",
       "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", null},
     {"firebase-db1.json", "google.firebase.database.document.v1.written",
-      "//firebase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz", null},
+      "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id", "refs/gcf-test/xyz"},
     {"firebase-auth1.json", "google.firebase.auth.user.v1.created",
-      "//firebase.googleapis.com/projects/my-project-id", null},
+      "//firebaseauth.googleapis.com/projects/my-project-id", "users/UUpby3s4spZre6kHsgVSPetzQ8l2"},
     {"firebase-auth2.json", "google.firebase.auth.user.v1.deleted",
-      "//firebase.googleapis.com/projects/my-project-id", null},
+      "//firebaseauth.googleapis.com/projects/my-project-id", "users/UUpby3s4spZre6kHsgVSPetzQ8l2"},
   };
 
   @Test
@@ -144,6 +145,8 @@ public class GcfEventsTest {
     Map<String, Object> data = cloudEventDataJson(cloudEvent);
     Map<?, ?> value = (Map<?, ?>) data.get("value");
     Map<?, ?> fields = (Map<?, ?>) value.get("fields");
+    Map<String, String> nullValues = new HashMap<String, String>();
+    nullValues.put("nullValue", null);
     Map<String, Object> expectedFields = Map.of(
         "arrayValue", Map.of("arrayValue",
             Map.of("values",
@@ -152,7 +155,7 @@ public class GcfEventsTest {
         "geoPointValue", Map.of("geoPointValue", Map.of("latitude", 51.4543, "longitude", -0.9781)),
         "intValue", Map.of("integerValue", "50"),
         "doubleValue", Map.of("doubleValue", 5.5),
-        "nullValue", Map.of(),
+        "nullValue", nullValues,
         "referenceValue", Map.of("referenceValue",
             "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"),
         "stringValue", Map.of("stringValue", "text"),

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
@@ -29,7 +29,7 @@ import java.io.StringReader;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Base64;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Ignore;
@@ -145,8 +145,6 @@ public class GcfEventsTest {
     Map<String, Object> data = cloudEventDataJson(cloudEvent);
     Map<?, ?> value = (Map<?, ?>) data.get("value");
     Map<?, ?> fields = (Map<?, ?>) value.get("fields");
-    Map<String, String> nullValues = new HashMap<String, String>();
-    nullValues.put("nullValue", null);
     Map<String, Object> expectedFields = Map.of(
         "arrayValue", Map.of("arrayValue",
             Map.of("values",
@@ -155,7 +153,7 @@ public class GcfEventsTest {
         "geoPointValue", Map.of("geoPointValue", Map.of("latitude", 51.4543, "longitude", -0.9781)),
         "intValue", Map.of("integerValue", "50"),
         "doubleValue", Map.of("doubleValue", 5.5),
-        "nullValue", nullValues,
+        "nullValue", Collections.singletonMap("nullValue", null),
         "referenceValue", Map.of("referenceValue",
             "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"),
         "stringValue", Map.of("stringValue", "text"),


### PR DESCRIPTION
This commit fixes a few bugs in the code that converts legacy events to
cloud events:
- preserve nulls when serializing JSON
- firebaseauth and firebasedatabase event types
- firebaseauth subject is derived form user ID in event data
- fix code to extract firebasedatabase subject from resourceName