### PR TITLE
Add conformance tests for background events

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -34,18 +34,27 @@ jobs:
       run: (cd invoker/ && mvn install)
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'http'
         useBuildpacks: false
-        validateMapping: false
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.HttpConformanceFunction'"
         startDelay: 10
 
+    - name: Run background event conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      with:
+        functionType: 'legacyevent'
+        useBuildpacks: false
+        validateMapping: false
+        cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.BackgroundEventConformanceFunction'"
+        startDelay: 10
+
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
+        validateMapping: false
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.CloudEventsConformanceFunction'"
         startDelay: 10

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/BackgroundEventConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/BackgroundEventConformanceFunction.java
@@ -1,0 +1,59 @@
+package com.google.cloud.functions.conformance;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.cloud.functions.Context;
+import com.google.cloud.functions.RawBackgroundFunction;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+
+/**
+ * This class is used by the Functions Framework Conformance Tools to validate
+ * the framework's Background Event API. It can be run with the following
+ * command:
+ *
+ * <pre>
+ * {@code
+ * $ functions-framework-conformance-client \
+ *   -cmd="mvn function:run -Drun.functionTarget=com.google.cloud.functions.conformance.BackgroundEventConformanceFunction" \
+ *   -type=legacyevent \
+ *   -buildpacks=false \
+ *   -validate-mapping=false \
+ *   -start-delay=10
+ * }
+ * </pre>
+ */
+public class BackgroundEventConformanceFunction implements RawBackgroundFunction {
+
+  private static final Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+
+  @Override
+  public void accept(String data, Context context) throws Exception {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter("function_output.json"))) {
+      writer.write(serialize(data, context));
+    }
+  }
+
+  /**
+   * Create a structured JSON representation of the request context and data
+   */
+  private String serialize(String data, Context context) {
+    JsonObject contextJson = new JsonObject();
+    contextJson.addProperty("eventId", context.eventId());
+    contextJson.addProperty("timestamp", context.timestamp());
+    contextJson.addProperty("eventType", context.eventType());
+    
+    JsonElement resource = gson.fromJson(context.resource(), JsonElement.class);
+    contextJson.add("resource", resource);
+
+    JsonObject dataJson = gson.fromJson(data, JsonObject.class);
+
+    JsonObject json = new JsonObject();
+    json.add("data", dataJson);
+    json.add("context", contextJson);
+    return gson.toJson(json);
+  }
+
+}

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -241,6 +241,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
   }
 
   private static class RawFunctionExecutor extends FunctionExecutor<Map<?, ?>> {
+    private static Gson gson = new GsonBuilder().serializeNulls().create();
     private final RawBackgroundFunction function;
 
     RawFunctionExecutor(RawBackgroundFunction function) {
@@ -250,7 +251,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
 
     @Override
     void serviceLegacyEvent(Event legacyEvent) throws Exception {
-      function.accept(new Gson().toJson(legacyEvent.getData()), legacyEvent.getContext());
+      function.accept(gson.toJson(legacyEvent.getData()), legacyEvent.getContext());
     }
 
     @Override


### PR DESCRIPTION
Previously we had been running conformance tests for background function signature types. This PR enables these tests in the conformance Github action.

Running the tests uncovered one bug in which JSON fields with null values were being dropped from the data param passed to RawBackgroundFunctions. Fixing this is a non-breaking change so I bumped the minor verison of the maven package using:

```bash
mvn versions:set -DnewVersion=1.1.0-SNAPSHOT -DprocessAllModules
```