### PR TITLE
fix local development with the Pub/Sub emulator

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
@@ -21,6 +21,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Represents an event that should be handled by a background function. This is an internal format
@@ -53,6 +55,31 @@ abstract class Event {
         context =
             jsonDeserializationContext.deserialize(
                 adjustContextResource(contextCopy), CloudFunctionsContext.class);
+      } else if (isPubSubEmulatorPayload(root)) {
+        JsonObject message = root.getAsJsonObject("message");
+
+        String timestampString = message.has("publishTime")
+          ? message.get("publishTime").getAsString()
+          : DateTimeFormatter.ISO_INSTANT.format(OffsetDateTime.now());
+
+        context = CloudFunctionsContext.builder()
+          .setEventType("google.pubsub.topic.publish")
+          .setTimestamp(timestampString)
+          .setEventId(message.get("messageId").getAsString())
+          .setResource("{" +
+              "\"name\":null," +
+              "\"service\":\"pubsub.googleapis.com\"," +
+              "\"type\":\"type.googleapis.com/google.pubsub.v1.PubsubMessage\""+
+            "}")
+          .build();
+
+        JsonObject marshalledData = new JsonObject();
+        marshalledData.addProperty("@type", "type.googleapis.com/google.pubsub.v1.PubsubMessage");
+        marshalledData.add("data", message.get("data"));
+        if (message.has("attributes")) {
+          marshalledData.add("attributes", message.get("attributes"));
+        }
+        data = marshalledData;
       } else {
         JsonObject rootCopy = root.deepCopy();
         rootCopy.remove("data");
@@ -61,6 +88,14 @@ abstract class Event {
                 adjustContextResource(rootCopy), CloudFunctionsContext.class);
       }
       return Event.of(data, context);
+    }
+
+    private boolean isPubSubEmulatorPayload(JsonObject root) {
+      if (root.has("subscription") && root.has("message") && root.get("message").isJsonObject()) {
+        JsonObject message = root.getAsJsonObject("message");
+        return message.has("data") && message.has("messageId");
+      }
+      return false;
     }
 
     /**

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
@@ -58,20 +58,23 @@ abstract class Event {
       } else if (isPubSubEmulatorPayload(root)) {
         JsonObject message = root.getAsJsonObject("message");
 
-        String timestampString = message.has("publishTime")
-          ? message.get("publishTime").getAsString()
-          : DateTimeFormatter.ISO_INSTANT.format(OffsetDateTime.now());
+        String timestampString =
+            message.has("publishTime")
+                ? message.get("publishTime").getAsString()
+                : DateTimeFormatter.ISO_INSTANT.format(OffsetDateTime.now());
 
-        context = CloudFunctionsContext.builder()
-          .setEventType("google.pubsub.topic.publish")
-          .setTimestamp(timestampString)
-          .setEventId(message.get("messageId").getAsString())
-          .setResource("{" +
-              "\"name\":null," +
-              "\"service\":\"pubsub.googleapis.com\"," +
-              "\"type\":\"type.googleapis.com/google.pubsub.v1.PubsubMessage\""+
-            "}")
-          .build();
+        context =
+            CloudFunctionsContext.builder()
+                .setEventType("google.pubsub.topic.publish")
+                .setTimestamp(timestampString)
+                .setEventId(message.get("messageId").getAsString())
+                .setResource(
+                    "{"
+                        + "\"name\":null,"
+                        + "\"service\":\"pubsub.googleapis.com\","
+                        + "\"type\":\"type.googleapis.com/google.pubsub.v1.PubsubMessage\""
+                        + "}")
+                .build();
 
         JsonObject marshalledData = new JsonObject();
         marshalledData.addProperty("@type", "type.googleapis.com/google.pubsub.v1.PubsubMessage");

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutorTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutorTest.java
@@ -2,13 +2,21 @@ package com.google.cloud.functions.invoker;
 
 import static com.google.cloud.functions.invoker.BackgroundFunctionExecutor.backgroundFunctionTypeArgument;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
+import com.google.gson.JsonObject;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 
 @RunWith(JUnit4.class)
 public class BackgroundFunctionExecutorTest {
@@ -61,5 +69,39 @@ public class BackgroundFunctionExecutorTest {
     Class<? extends BackgroundFunction<?>> c =
         (Class<? extends BackgroundFunction<?>>) (Class<?>) ForgotTypeParameter.class;
     assertThat(backgroundFunctionTypeArgument(c)).isEmpty();
+  }
+
+  @Test
+  public void parseLegacyEventPubSub() throws IOException {
+    try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/pubsub_background.json"))) {
+      Event event = BackgroundFunctionExecutor.parseLegacyEvent(reader);
+
+      Context context = event.getContext();
+      assertEquals("google.pubsub.topic.publish", context.eventType());
+      assertEquals("1", context.eventId());
+      assertEquals("2021-06-28T05:46:32.390Z", context.timestamp());
+
+      JsonObject data = event.getData().getAsJsonObject();
+      assertEquals(data.get("data").getAsString(), "eyJmb28iOiJiYXIifQ==");
+      String attr = data.get("attributes").getAsJsonObject().get("test").getAsString();
+      assertEquals(attr, "123");
+    }
+  }
+
+  @Test
+  public void parseLegacyEventPubSubEmulator() throws IOException {
+    try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/pubsub_emulator.json"))) {
+      Event event = BackgroundFunctionExecutor.parseLegacyEvent(reader);
+
+      Context context = event.getContext();
+      assertEquals("google.pubsub.topic.publish", context.eventType());
+      assertEquals("1", context.eventId());
+      assertNotNull(context.timestamp());
+
+      JsonObject data = event.getData().getAsJsonObject();
+      assertEquals(data.get("data").getAsString(), "eyJmb28iOiJiYXIifQ==");
+      String attr = data.get("attributes").getAsJsonObject().get("test").getAsString();
+      assertEquals(attr, "123");
+    }
   }
 }

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutorTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutorTest.java
@@ -1,14 +1,12 @@
 package com.google.cloud.functions.invoker;
 
 import static com.google.cloud.functions.invoker.BackgroundFunctionExecutor.backgroundFunctionTypeArgument;
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
 import com.google.gson.JsonObject;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -16,7 +14,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 
 @RunWith(JUnit4.class)
 public class BackgroundFunctionExecutorTest {
@@ -28,7 +25,8 @@ public class BackgroundFunctionExecutorTest {
   }
 
   private static class PubSubFunction implements BackgroundFunction<PubSubMessage> {
-    @Override public void accept(PubSubMessage payload, Context context) {}
+    @Override
+    public void accept(PubSubMessage payload, Context context) {}
   }
 
   @Test
@@ -39,7 +37,8 @@ public class BackgroundFunctionExecutorTest {
   private abstract static class Parent implements BackgroundFunction<PubSubMessage> {}
 
   private static class Child extends Parent {
-    @Override public void accept(PubSubMessage payload, Context context) {}
+    @Override
+    public void accept(PubSubMessage payload, Context context) {}
   }
 
   @Test
@@ -50,7 +49,8 @@ public class BackgroundFunctionExecutorTest {
   private interface GenericParent<T> extends BackgroundFunction<T> {}
 
   private static class GenericChild implements GenericParent<PubSubMessage> {
-    @Override public void accept(PubSubMessage payload, Context context) {}
+    @Override
+    public void accept(PubSubMessage payload, Context context) {}
   }
 
   @Test
@@ -60,7 +60,8 @@ public class BackgroundFunctionExecutorTest {
 
   @SuppressWarnings("rawtypes")
   private static class ForgotTypeParameter implements BackgroundFunction {
-    @Override public void accept(Object payload, Context context) {}
+    @Override
+    public void accept(Object payload, Context context) {}
   }
 
   @Test
@@ -73,35 +74,38 @@ public class BackgroundFunctionExecutorTest {
 
   @Test
   public void parseLegacyEventPubSub() throws IOException {
-    try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/pubsub_background.json"))) {
+    try (Reader reader =
+        new InputStreamReader(getClass().getResourceAsStream("/pubsub_background.json"))) {
       Event event = BackgroundFunctionExecutor.parseLegacyEvent(reader);
 
       Context context = event.getContext();
-      assertEquals("google.pubsub.topic.publish", context.eventType());
-      assertEquals("1", context.eventId());
-      assertEquals("2021-06-28T05:46:32.390Z", context.timestamp());
+      assertThat(context.eventType()).isEqualTo("google.pubsub.topic.publish");
+      assertThat(context.eventId()).isEqualTo("1");
+      assertThat(context.timestamp()).isEqualTo("2021-06-28T05:46:32.390Z");
 
       JsonObject data = event.getData().getAsJsonObject();
-      assertEquals(data.get("data").getAsString(), "eyJmb28iOiJiYXIifQ==");
+      assertThat(data.get("data").getAsString()).isEqualTo("eyJmb28iOiJiYXIifQ==");
       String attr = data.get("attributes").getAsJsonObject().get("test").getAsString();
-      assertEquals(attr, "123");
+      assertThat(attr).isEqualTo("123");
     }
   }
 
   @Test
   public void parseLegacyEventPubSubEmulator() throws IOException {
-    try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/pubsub_emulator.json"))) {
+    try (Reader reader =
+        new InputStreamReader(getClass().getResourceAsStream("/pubsub_emulator.json"))) {
       Event event = BackgroundFunctionExecutor.parseLegacyEvent(reader);
 
       Context context = event.getContext();
-      assertEquals("google.pubsub.topic.publish", context.eventType());
-      assertEquals("1", context.eventId());
-      assertNotNull(context.timestamp());
+      assertThat(context.eventType()).isEqualTo("google.pubsub.topic.publish");
+      assertThat(context.eventId()).isEqualTo("1");
+      assertThat(context.timestamp()).isNotNull();
+      ;
 
       JsonObject data = event.getData().getAsJsonObject();
-      assertEquals(data.get("data").getAsString(), "eyJmb28iOiJiYXIifQ==");
+      assertThat(data.get("data").getAsString()).isEqualTo("eyJmb28iOiJiYXIifQ==");
       String attr = data.get("attributes").getAsJsonObject().get("test").getAsString();
-      assertEquals(attr, "123");
+      assertThat(attr).isEqualTo("123");
     }
   }
 }

--- a/invoker/core/src/test/resources/pubsub_background.json
+++ b/invoker/core/src/test/resources/pubsub_background.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "data": "eyJmb28iOiJiYXIifQ==",
+    "attributes": {
+      "test": "123"
+    }
+  },
+  "context": {
+    "eventId": "1",
+    "eventType": "google.pubsub.topic.publish",
+    "resource": {
+      "name": "projects/FOO/topics/BAR_TOPIC",
+      "service": "pubsub.googleapis.com",
+      "type": "type.googleapis.com/google.pubsub.v1.PubsubMessage"
+    },
+    "timestamp": "2021-06-28T05:46:32.390Z"
+  }
+}

--- a/invoker/core/src/test/resources/pubsub_emulator.json
+++ b/invoker/core/src/test/resources/pubsub_emulator.json
@@ -1,0 +1,10 @@
+{
+  "subscription": "projects/FOO/subscriptions/BAR_SUB",
+  "message": {
+    "data": "eyJmb28iOiJiYXIifQ==",
+    "messageId": "1",
+    "attributes": {
+      "test": "123"
+    }
+  }
+}


### PR DESCRIPTION
Currently, the functions frameworks are dependent on some private
dataplane event marshalling logic in order to correctly pass PubSub
events to background functions. This commit implements the same
marshalling logic in the FF in order to enable local development using
the [PubSub emulator](https://cloud.google.com/pubsub/docs/emulator).

We have already implemented this change in other function frameworks:
https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/272
https://github.com/GoogleCloudPlatform/functions-framework-ruby/pull/100
https://github.com/GoogleCloudPlatform/functions-framework-python/pull/121
https://github.com/GoogleCloudPlatform/functions-framework-go/pull/70