### PR TITLE
Update CloudEvent conversion logic

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -55,6 +55,6 @@ jobs:
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.CloudEventsConformanceFunction'"
         startDelay: 10

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudFunctionsContext.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudFunctionsContext.java
@@ -50,6 +50,9 @@ abstract class CloudFunctionsContext implements Context {
   // TODO: expose this in the Context interface (as a default method).
   abstract Map<String, String> params();
 
+  @Nullable
+  abstract String domain();
+
   @Override
   public abstract Map<String, String> attributes();
 
@@ -71,6 +74,7 @@ abstract class CloudFunctionsContext implements Context {
     abstract Builder setResource(String x);
     abstract Builder setParams(Map<String, String> x);
     abstract Builder setAttributes(Map<String, String> value);
+    abstract Builder setDomain(String x);
 
     abstract CloudFunctionsContext build();
   }

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/GcfEventsTest.java
@@ -52,7 +52,11 @@ public class GcfEventsTest {
     {"legacy_pubsub.json", "google.cloud.pubsub.topic.v1.messagePublished",
       "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", null},
     {"firebase-db1.json", "google.firebase.database.document.v1.written",
-      "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id", "refs/gcf-test/xyz"},
+      "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+      "refs/gcf-test/xyz"},
+    {"firebase-db2.json", "google.firebase.database.document.v1.written",
+      "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
+      "refs/gcf-test/xyz"},
     {"firebase-auth1.json", "google.firebase.auth.user.v1.created",
       "//firebaseauth.googleapis.com/projects/my-project-id", "users/UUpby3s4spZre6kHsgVSPetzQ8l2"},
     {"firebase-auth2.json", "google.firebase.auth.user.v1.deleted",
@@ -211,7 +215,9 @@ public class GcfEventsTest {
     assertThat(new String(cloudEvent.getData().toBytes(), UTF_8))
         .isEqualTo("{\"message\":{\"@type\":\"type.googleapis.com/google.pubsub.v1.PubsubMessage\","
             + "\"attributes\":{\"attribute1\":\"value1\"},"
-            + "\"data\":\"VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl\"}}");
+            + "\"data\":\"VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl\","
+            + "\"messageId\":\"1215011316659232\","
+            + "\"publishTime\":\"2020-05-18T12:13:19.209Z\"}}");
   }
 
   // Checks that a Firestore event correctly gets an extra "wildcards" property in its CloudEvent data

--- a/invoker/core/src/test/resources/firebase-db2.json
+++ b/invoker/core/src/test/resources/firebase-db2.json
@@ -6,14 +6,16 @@
   "auth": {
     "admin": true
   },
-  "domain": "firebaseio.com",
+  "domain":"europe-west1.firebasedatabase.app",
   "data": {
-    "data": null,
-    "delta": {
+    "data": {
       "grandchild": "other"
+    },
+    "delta": {
+      "grandchild": "other changed"
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-05-21T11:15:34.178Z",
-  "eventId": "/SnHth9OSlzK1Puj85kk4tDbF90="
+  "timestamp": "2020-09-29T11:32:00.000Z",
+  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }


### PR DESCRIPTION
This commit updates the logic for converting legacy events to CloudEvents. Specifically two changes were required:

- [firebasedb event location should be inferred from the domain field](https://github.com/GoogleCloudPlatform/functions-framework-conformance/blob/master/docs/mapping.md#firebase-rtdb-events-tentative)
- [messageId and publishTime should be populated in the PubSub message](https://github.com/GoogleCloudPlatform/functions-framework-conformance/blob/master/docs/mapping.md#cloud-pubsub-events)

With this change `validate_mapping` can be re-enabled for cloudevent conformance tests.