### PR TITLE
fix: make user function exceptions log level SEVERE

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -333,7 +333,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
       res.setStatus(HttpServletResponse.SC_OK);
     } catch (Throwable t) {
       res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      logger.log(Level.WARNING, "Failed to execute " + functionExecutor.functionName(), t);
+      logger.log(Level.SEVERE, "Failed to execute " + functionExecutor.functionName(), t);
     }
   }
 

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/HttpFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/HttpFunctionExecutor.java
@@ -66,11 +66,7 @@ public class HttpFunctionExecutor extends HttpServlet {
       Thread.currentThread().setContextClassLoader(function.getClass().getClassLoader());
       function.service(reqImpl, respImpl);
     } catch (Throwable t) {
-      // TODO(b/146510646): this should be logged properly as an exception, but that currently
-      //   causes integration tests to fail.
-      // logger.log(Level.WARNING, "Failed to execute " + function.getClass().getName(), t);
-      logger.log(Level.WARNING, "Failed to execute {0}", function.getClass().getName());
-      t.printStackTrace();
+      logger.log(Level.SEVERE, "Failed to execute " + function.getClass().getName(), t);
       res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     } finally {
       Thread.currentThread().setContextClassLoader(oldContextLoader);

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -249,6 +249,48 @@ public class IntegrationTest {
   }
 
   @Test
+  public void exceptionHttp() throws Exception {
+    String exceptionExpectedOutput =
+        "\"severity\": \"ERROR\", \"logging.googleapis.com/sourceLocation\": {\"file\":"
+            + " \"com/google/cloud/functions/invoker/HttpFunctionExecutor.java\", \"method\":"
+            + " \"service\"}, \"message\": \"Failed to execute"
+            + " com.google.cloud.functions.invoker.testfunctions.ExceptionHttp\\n"
+            + "java.lang.RuntimeException: exception thrown for test";
+    testHttpFunction(
+        fullTarget("ExceptionHttp"),
+        ImmutableList.of(
+            TestCase.builder()
+                .setExpectedResponseCode(500)
+                .setExpectedOutput(exceptionExpectedOutput)
+                .build()));
+  }
+
+
+  @Test
+  public void exceptionBackground() throws Exception {
+    String exceptionExpectedOutput =
+        "\"severity\": \"ERROR\", \"logging.googleapis.com/sourceLocation\": {\"file\":"
+            + " \"com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java\", \"method\":"
+            + " \"service\"}, \"message\": \"Failed to execute"
+            + " com.google.cloud.functions.invoker.testfunctions.ExceptionBackground\\n"
+            + "java.lang.RuntimeException: exception thrown for test";
+
+    File snoopFile = snoopFile();
+    String gcfRequestText = sampleLegacyEvent(snoopFile);
+
+    testFunction(
+        SignatureType.BACKGROUND,
+        fullTarget("ExceptionBackground"),
+        ImmutableList.of(),
+        ImmutableList.of(
+            TestCase.builder()
+                .setRequestText(gcfRequestText)
+                .setExpectedResponseCode(500)
+                .setExpectedOutput(exceptionExpectedOutput)
+                .build()));
+  }
+
+  @Test
   public void echo() throws Exception {
     String testText = "hello\nworld\n";
     testHttpFunction(

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/ExceptionBackground.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/ExceptionBackground.java
@@ -1,0 +1,11 @@
+package com.google.cloud.functions.invoker.testfunctions;
+
+import com.google.cloud.functions.Context;
+import com.google.cloud.functions.RawBackgroundFunction;
+
+public class ExceptionBackground implements RawBackgroundFunction {
+  @Override
+  public void accept(String json, Context context) {
+    throw new RuntimeException("exception thrown for test");
+  }
+}

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/ExceptionHttp.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/ExceptionHttp.java
@@ -1,0 +1,12 @@
+package com.google.cloud.functions.invoker.testfunctions;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+public class ExceptionHttp implements HttpFunction {
+  @Override
+  public void service(HttpRequest request, HttpResponse response) throws Exception {
+    throw new RuntimeException("exception thrown for test");
+  }
+}


### PR DESCRIPTION
The FF is inconsistent in how it logs errors in the user function
between HTTP functions and Event-driven functions. This change makes it
so that all functions log the same error with the same severity if
the user function throws an exception.

Log level SEVERE is required to be consistent with the Cloud Functions &
Error Reporting
[docs](https://cloud.google.com/error-reporting/docs/setup/nodejs#cloud_functions).