### PR TITLE
fix: enable conversions validation in conformance tests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         functionType: 'legacyevent'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.BackgroundEventConformanceFunction'"
         startDelay: 10
 


### PR DESCRIPTION
The flag to validate cloudevent to legacy events was not enabled.