### PR TITLE
feat: enable converting CloudEvent requests to Background Event requests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -34,25 +34,28 @@ jobs:
       run: (cd invoker/ && mvn install)
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
+        version: 'v1.2.1'
         functionType: 'http'
         useBuildpacks: false
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.HttpConformanceFunction'"
         startDelay: 10
 
     - name: Run background event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
+        version: 'v1.2.1'
         functionType: 'legacyevent'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.BackgroundEventConformanceFunction'"
         startDelay: 10
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
+        version: 'v1.2.1'
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: true

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -34,6 +34,16 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-core</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-json-jackson</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/BackgroundEventConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/BackgroundEventConformanceFunction.java
@@ -40,8 +40,12 @@ public class BackgroundEventConformanceFunction implements RawBackgroundFunction
     contextJson.addProperty("timestamp", context.timestamp());
     contextJson.addProperty("eventType", context.eventType());
 
-    JsonElement resource = gson.fromJson(context.resource(), JsonElement.class);
-    contextJson.add("resource", resource);
+    if (context.resource().startsWith("{")) {
+      JsonElement resource = gson.fromJson(context.resource(), JsonElement.class);
+      contextJson.add("resource", resource);
+    } else {
+      contextJson.addProperty("resource", context.resource());
+    }
 
     JsonObject dataJson = gson.fromJson(data, JsonObject.class);
 

--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -131,6 +131,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
+      <version>1.6</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -14,7 +14,6 @@
 
 package com.google.cloud.functions.invoker;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -263,10 +262,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
 
     @Override
     void serviceCloudEvent(CloudEvent cloudEvent) throws Exception {
-      Context context = contextFromCloudEvent(cloudEvent);
-      String jsonData =
-          (cloudEvent.getData() == null) ? "{}" : new String(cloudEvent.getData().toBytes(), UTF_8);
-      function.accept(jsonData, context);
+      serviceLegacyEvent(CloudEvents.convertToLegacyEvent(cloudEvent));
     }
   }
 
@@ -295,10 +291,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
     @Override
     void serviceCloudEvent(CloudEvent cloudEvent) throws Exception {
       if (cloudEvent.getData() != null) {
-        String data = new String(cloudEvent.getData().toBytes(), UTF_8);
-        T payload = new Gson().fromJson(data, type);
-        Context context = contextFromCloudEvent(cloudEvent);
-        function.accept(payload, context);
+        serviceLegacyEvent(CloudEvents.convertToLegacyEvent(cloudEvent));
       } else {
         throw new IllegalStateException("Event has no \"data\" component");
       }

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudEvents.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudEvents.java
@@ -1,0 +1,296 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.functions.invoker;
+
+import static java.util.Map.entry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import io.cloudevents.CloudEvent;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+
+/** Conversions from CloudEvents events to GCF Background Events. */
+class CloudEvents {
+  private static final String PUB_SUB_MESSAGE_TYPE =
+      "type.googleapis.com/google.pubsub.v1.PubsubMessage";
+
+  private static final Map<String, EventAdapter> EVENT_TYPE_MAPPING =
+      Map.ofEntries(
+          entry(
+              "google.cloud.pubsub.topic.v1.messagePublished",
+              new PubSubEventAdapter("google.pubsub.topic.publish")),
+          entry(
+              "google.cloud.storage.object.v1.finalized",
+              new StorageEventAdapter("google.storage.object.finalize")),
+          entry(
+              "google.cloud.storage.object.v1.deleted",
+              new StorageEventAdapter("google.storage.object.delete")),
+          entry(
+              "google.cloud.storage.object.v1.archived",
+              new StorageEventAdapter("google.storage.object.archive")),
+          entry(
+              "google.cloud.storage.object.v1.metadataUpdated",
+              new StorageEventAdapter("google.storage.object.metadataUpdate")),
+          entry(
+              "google.cloud.firestore.document.v1.written",
+              new EventAdapter("providers/cloud.firestore/eventTypes/document.write")),
+          entry(
+              "google.cloud.firestore.document.v1.created",
+              new EventAdapter("providers/cloud.firestore/eventTypes/document.create")),
+          entry(
+              "google.cloud.firestore.document.v1.updated",
+              new EventAdapter("providers/cloud.firestore/eventTypes/document.update")),
+          entry(
+              "google.cloud.firestore.document.v1.deleted",
+              new EventAdapter("providers/cloud.firestore/eventTypes/document.delete")),
+          entry(
+              "google.firebase.analytics.log.v1.written",
+              new EventAdapter("providers/google.firebase.analytics/eventTypes/event.log")),
+          entry(
+              "google.firebase.auth.user.v1.created",
+              new FirebaseAuthEventAdapter("providers/firebase.auth/eventTypes/user.create")),
+          entry(
+              "google.firebase.auth.user.v1.deleted",
+              new FirebaseAuthEventAdapter("providers/firebase.auth/eventTypes/user.delete")),
+          entry(
+              "google.firebase.database.ref.v1.created",
+              new FirebaseDatabaseEventAdapter(
+                  "providers/google.firebase.database/eventTypes/ref.create")),
+          entry(
+              "google.firebase.database.ref.v1.written",
+              new FirebaseDatabaseEventAdapter(
+                  "providers/google.firebase.database/eventTypes/ref.write")),
+          entry(
+              "google.firebase.database.ref.v1.updated",
+              new FirebaseDatabaseEventAdapter(
+                  "providers/google.firebase.database/eventTypes/ref.update")),
+          entry(
+              "google.firebase.database.ref.v1.deleted",
+              new FirebaseDatabaseEventAdapter(
+                  "providers/google.firebase.database/eventTypes/ref.delete")),
+          entry(
+              "google.cloud.storage.object.v1.changed",
+              new StorageEventAdapter("providers/cloud.storage/eventTypes/object.change")));
+
+  private static final Gson GSON = new GsonBuilder().serializeNulls().create();
+
+  /**
+   * Converts a CloudEvent to the legacy event format.
+   *
+   * @param cloudEvent the CloudEvent to convert
+   * @return the legacy event representation of the Cloud Event
+   */
+  static Event convertToLegacyEvent(CloudEvent cloudEvent) {
+    String eventType = cloudEvent.getType();
+    EventAdapter eventAdapter = EVENT_TYPE_MAPPING.get(eventType);
+    if (eventAdapter == null) {
+      throw new IllegalArgumentException("Unrecognized CloudEvent type \"" + eventType + "\"");
+    }
+    return eventAdapter.convertToLegacyEvent(cloudEvent);
+  }
+
+  private static class EventAdapter {
+    private final String legacyEventType;
+    private static Pattern sourcePattern = Pattern.compile("//([^/]+)/(.+)");
+
+    protected class ParsedCloudEvent {
+      public final String Resource;
+      public final String Service;
+      public final String Name;
+
+      public ParsedCloudEvent(String resource, String service, String name) {
+        this.Resource = resource;
+        this.Service = service;
+        this.Name = name;
+      }
+    }
+    ;
+
+    /**
+     * Creates an adapter to convert from the CloudEvent to a legacy event.
+     *
+     * @param legacyEventType the event type of the legacy event being created
+     */
+    EventAdapter(String legacyEventType) {
+      this.legacyEventType = legacyEventType;
+    }
+
+    /**
+     * Converts a CloudEvent to the legacy event format.
+     *
+     * @param cloudEvent the CloudEvent to convert
+     * @return the legacy event representation of the Cloud Event
+     */
+    final Event convertToLegacyEvent(CloudEvent cloudEvent) {
+      /*
+        Ex 1: "//firebaseauth.googleapis.com/projects/my-project-id"
+        m.group(0): "//firebaseauth.googleapis.com/projects/my-project-id"
+        m.group(1): "firebaseauth.googleapis.com"
+        m.group(2): "projects/my-project-id"
+
+        Ex 2: "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test"
+        m.group(0): "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test"
+        m.group(1): "pubsub.googleapis.com"
+        m.group(2): "projects/sample-project/topics/gcf-test"
+      */
+      Matcher m = sourcePattern.matcher(cloudEvent.getSource().toString());
+      if (!m.find() || m.groupCount() != 2) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Invalid CloudEvent source '%s', unable to parse into resource service and name",
+                cloudEvent.getSource().toString()));
+      }
+
+      String service = m.group(1);
+      String name = m.group(2);
+      String resource = String.format("%s/%s", name, cloudEvent.getSubject());
+      ParsedCloudEvent parsed = new ParsedCloudEvent(resource, service, name);
+
+      OffsetDateTime timestamp =
+          Optional.ofNullable(cloudEvent.getTime()).orElse(OffsetDateTime.now());
+
+      CloudFunctionsContext.Builder ctxBuilder =
+          CloudFunctionsContext.builder()
+              .setEventId(cloudEvent.getId())
+              .setEventType(this.legacyEventType)
+              .setResource(resource)
+              .setTimestamp(DateTimeFormatter.ISO_INSTANT.format(timestamp));
+
+      JsonObject data =
+          GSON.fromJson(
+              new String(cloudEvent.getData().toBytes(), java.nio.charset.StandardCharsets.UTF_8),
+              JsonObject.class);
+      return createLegacyEvent(parsed, ctxBuilder, data);
+    }
+
+    /**
+     * Provides a hook to furither modify the converted event for specific event adapter subclasses.
+     *
+     * @param event convenient information parsed from the original CloudEvent
+     * @param builder the builder for the converted legacy event's context, pre-populated with
+     *     defaults from the original CloudEvent
+     * @param data the data for the converted legacy event's data, pre-populated with defaults from
+     *     the original CloudEvent
+     * @return the fully converted legacy event
+     */
+    Event createLegacyEvent(
+        ParsedCloudEvent event, CloudFunctionsContext.Builder builder, JsonObject data) {
+      return Event.of(data, builder.build());
+    }
+  }
+
+  private static class PubSubEventAdapter extends EventAdapter {
+    PubSubEventAdapter(String legacyEventType) {
+      super(legacyEventType);
+    }
+
+    @Override
+    Event createLegacyEvent(
+        ParsedCloudEvent event, CloudFunctionsContext.Builder builder, JsonObject data) {
+      JsonObject resource = new JsonObject();
+      resource.addProperty("service", event.Service);
+      resource.addProperty("name", event.Name);
+      resource.addProperty("type", PUB_SUB_MESSAGE_TYPE);
+      builder.setResource(GSON.toJson(resource));
+
+      // Lift the "message" field into the main "data" field.
+      if (data.has("message")) {
+        JsonElement message = data.get("message");
+        if (message.isJsonObject()) {
+          data = message.getAsJsonObject();
+        }
+      }
+
+      data.remove("messageId");
+      data.remove("publishTime");
+
+      return Event.of(data, builder.build());
+    }
+  }
+
+  private static class FirebaseAuthEventAdapter extends EventAdapter {
+    FirebaseAuthEventAdapter(String legacyEventType) {
+      super(legacyEventType);
+    }
+
+    @Override
+    Event createLegacyEvent(
+        ParsedCloudEvent event, CloudFunctionsContext.Builder builder, JsonObject data) {
+      builder.setResource(event.Name);
+
+      if (data.has("metadata")) {
+        JsonElement meta = data.get("metadata");
+        if (meta.isJsonObject()) {
+          JsonObject metaObj = meta.getAsJsonObject();
+
+          JsonElement createTime = metaObj.get("createTime");
+          if (createTime != null) {
+            metaObj.add("createdAt", createTime);
+            metaObj.remove("createTime");
+          }
+
+          JsonElement lastSignInTime = metaObj.get("lastSignInTime");
+          if (lastSignInTime != null) {
+            metaObj.add("lastSignedInAt", lastSignInTime);
+            metaObj.remove("lastSignInTime");
+          }
+        }
+      }
+      return Event.of(data, builder.build());
+    }
+  }
+
+  private static class FirebaseDatabaseEventAdapter extends EventAdapter {
+    private static Pattern resourcePattern = Pattern.compile("/locations/[^/]+");
+
+    FirebaseDatabaseEventAdapter(String legacyEventType) {
+      super(legacyEventType);
+    }
+
+    @Override
+    Event createLegacyEvent(
+        ParsedCloudEvent event, CloudFunctionsContext.Builder builder, JsonObject data) {
+      builder.setResource(resourcePattern.matcher(event.Resource).replaceAll(""));
+      return Event.of(data, builder.build());
+    }
+  }
+
+  private static class StorageEventAdapter extends EventAdapter {
+    StorageEventAdapter(String legacyEventType) {
+      super(legacyEventType);
+    }
+
+    @Override
+    Event createLegacyEvent(
+        ParsedCloudEvent event, CloudFunctionsContext.Builder builder, JsonObject data) {
+      JsonObject resource = new JsonObject();
+      resource.addProperty("service", event.Service);
+      resource.addProperty("name", event.Resource);
+      if (data.has("kind")) {
+        resource.addProperty("type", data.get("kind").getAsString());
+      }
+
+      builder.setResource(GSON.toJson(resource));
+      return Event.of(data, builder.build());
+    }
+  }
+}

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudFunctionsContext.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/CloudFunctionsContext.java
@@ -103,17 +103,12 @@ abstract class CloudFunctionsContext implements Context {
     }
 
     static Resource from(String s) {
-      Gson baseGson = new Gson();
-      if (s.startsWith("\"") && s.endsWith("\"")) {
-        String name = baseGson.fromJson(s, String.class);
-        return builder().setName(name).build();
-      }
       if (s.startsWith("{") && (s.endsWith("}") || s.endsWith("}\n"))) {
-        TypeAdapter<Resource> typeAdapter = typeAdapter(baseGson);
+        TypeAdapter<Resource> typeAdapter = typeAdapter(new Gson());
         Gson gson = new GsonBuilder().registerTypeAdapter(Resource.class, typeAdapter).create();
         return gson.fromJson(s, Resource.class);
       }
-      throw new IllegalArgumentException("Unexpected resource syntax: " + s);
+      return builder().setName(s).build();
     }
 
     static Builder builder() {

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/Event.java
@@ -107,10 +107,12 @@ abstract class Event {
      * to be a string.
      */
     private JsonObject adjustContextResource(JsonObject contextObject) {
-      String resourceValue =
-          contextObject.has("resource") ? contextObject.get("resource").toString() : "";
-      contextObject.remove("resource");
-      contextObject.addProperty("resource", resourceValue);
+      if (contextObject.has("resource")) {
+        JsonElement resourceElement = contextObject.get("resource");
+        if (resourceElement.isJsonObject()) {
+          contextObject.addProperty("resource", resourceElement.toString());
+        }
+      }
       return contextObject;
     }
   }

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/CloudEventsTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/CloudEventsTest.java
@@ -1,0 +1,100 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.functions.invoker;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.jackson.JsonFormat;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import org.junit.Test;
+
+public class CloudEventsTest {
+  @Test
+  public void firebaseFirestoreTest() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("firestore_complex-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("firestore_complex-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  @Test
+  public void pubSubTest() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("pubsub_text-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("pubsub_text-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  @Test
+  public void firebaseAuthTest() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("firebase-auth-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("firebase-auth-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  @Test
+  public void firebaseDb1Test() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("firebase-db1-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("firebase-db1-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  @Test
+  public void firebaseDb2Test() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("firebase-db2-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("firebase-db2-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  @Test
+  public void storageTest() throws Exception {
+    CloudEvent cloudEvent = cloudEventForResource("storage-cloudevent-input.json");
+    Event actualEvent = CloudEvents.convertToLegacyEvent(cloudEvent);
+
+    Event expEvent = legacyEventForResource("storage-legacy-output.json");
+    assertThat(actualEvent).isEqualTo(expEvent);
+  }
+
+  private CloudEvent cloudEventForResource(String resourceName) throws IOException {
+    try (InputStream in = getClass().getResourceAsStream("/" + resourceName)) {
+      assertWithMessage("No such resource /%s", resourceName).that(in).isNotNull();
+      byte[] req = in.readAllBytes();
+      return io.cloudevents.core.provider.EventFormatProvider.getInstance()
+          .resolveFormat(JsonFormat.CONTENT_TYPE)
+          .deserialize(req);
+    }
+  }
+
+  private Event legacyEventForResource(String resourceName) throws IOException {
+    try (InputStream in = getClass().getResourceAsStream("/" + resourceName)) {
+      assertWithMessage("No such resource /%s", resourceName).that(in).isNotNull();
+      String legacyEventString = new String(in.readAllBytes(), UTF_8);
+      return BackgroundFunctionExecutor.parseLegacyEvent(new StringReader(legacyEventString));
+    }
+  }
+}

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -103,11 +103,11 @@ public class IntegrationTest {
         + "  \"context\": {\n"
         + "    \"eventId\": \"B234-1234-1234\",\n"
         + "    \"timestamp\": \"2018-04-05T17:31:00Z\",\n"
-        + "    \"eventType\": \"com.example.someevent.new\",\n"
+        + "    \"eventType\": \"google.pubsub.topic.publish\",\n"
         + "    \"resource\": {\n"
-        + "      \"service\":\"test-service\",\n"
-        + "      \"name\":\"test-name\",\n"
-        + "      \"type\":\"test-type\"\n"
+        + "      \"service\":\"pubsub.googleapis.com\",\n"
+        + "      \"name\":\"projects/sample-project/topics/gcf-test\",\n"
+        + "      \"type\":\"type.googleapis.com/google.pubsub.v1.PubsubMessage\"\n"
         + "    }\n"
         + "  }\n"
         + "}";
@@ -116,8 +116,9 @@ public class IntegrationTest {
   private static CloudEvent sampleCloudEvent(File snoopFile) {
     return CloudEventBuilder.v1()
         .withId("B234-1234-1234")
-        .withSource(URI.create("/source"))
-        .withType("com.example.someevent.new")
+        .withSource(URI.create("//pubsub.googleapis.com/projects/sample-project/topics/gcf-test"))
+        .withSubject("documents/gcf-test/2Vm2mI1d0wIaK2Waj5to")
+        .withType("google.cloud.pubsub.topic.v1.messagePublished")
         .withDataSchema(URI.create("/schema"))
         .withDataContentType("application/json")
         .withData(("{\"a\": 2, \"b\": 3, \"targetFile\": \"" + snoopFile + "\"}").getBytes(UTF_8))
@@ -386,8 +387,6 @@ public class IntegrationTest {
     File snoopFile = snoopFile();
     String gcfRequestText = sampleLegacyEvent(snoopFile);
     JsonObject expectedJson = new Gson().fromJson(gcfRequestText, JsonObject.class);
-    // We don't currently put anything in the attributes() map for legacy events.
-    expectedJson.add("attributes", new JsonObject());
     TestCase gcfTestCase =
         TestCase.builder()
             .setRequestText(gcfRequestText)
@@ -404,8 +403,6 @@ public class IntegrationTest {
     // For CloudEvents, we don't currently populate Context#getResource with anything interesting,
     // so we excise that from the expected text we would have with legacy events.
     JsonObject cloudEventExpectedJson = new Gson().fromJson(gcfRequestText, JsonObject.class);
-    cloudEventExpectedJson.getAsJsonObject("context").add("resource", new JsonObject());
-    cloudEventExpectedJson.add("attributes", expectedCloudEventAttributes());
     TestCase cloudEventsStructuredTestCase =
         TestCase.builder()
             .setSnoopFile(snoopFile)

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/BackgroundSnoop.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/BackgroundSnoop.java
@@ -34,7 +34,6 @@ public class BackgroundSnoop implements RawBackgroundFunction {
     JsonObject contextAndPayloadJson = new JsonObject();
     contextAndPayloadJson.add("data", jsonObject);
     contextAndPayloadJson.add("context", contextJson);
-    contextAndPayloadJson.add("attributes", gson.toJsonTree(context.attributes()));
     try (FileWriter fileWriter = new FileWriter(targetFile);
         PrintWriter writer = new PrintWriter(fileWriter)) {
       writer.println(contextAndPayloadJson);

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/TypedBackgroundSnoop.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/TypedBackgroundSnoop.java
@@ -39,7 +39,6 @@ public class TypedBackgroundSnoop implements BackgroundFunction<TypedBackgroundS
     JsonObject contextAndPayloadJson = new JsonObject();
     contextAndPayloadJson.add("data", gson.toJsonTree(payload));
     contextAndPayloadJson.add("context", contextJson);
-    contextAndPayloadJson.add("attributes", gson.toJsonTree(context.attributes()));
     try (FileWriter fileWriter = new FileWriter(targetFile);
         PrintWriter writer = new PrintWriter(fileWriter)) {
       writer.println(contextAndPayloadJson);

--- a/invoker/core/src/test/resources/firebase-auth-cloudevent-input.json
+++ b/invoker/core/src/test/resources/firebase-auth-cloudevent-input.json
@@ -1,0 +1,24 @@
+{
+  "specversion": "1.0",
+  "type": "google.firebase.auth.user.v1.created",
+  "source": "//firebaseauth.googleapis.com/projects/my-project-id",
+  "subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "email": "test@nowhere.com",
+    "metadata": {
+      "createTime": "2020-05-26T10:42:27Z",
+      "lastSignInTime": "2020-10-24T11:00:00Z"
+    },
+    "providerData": [
+      {
+        "email": "test@nowhere.com",
+        "providerId": "password",
+        "uid": "test@nowhere.com"
+      }
+    ],
+    "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+  }
+}

--- a/invoker/core/src/test/resources/firebase-auth-legacy-output.json
+++ b/invoker/core/src/test/resources/firebase-auth-legacy-output.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "email": "test@nowhere.com",
+    "metadata": {
+      "createdAt": "2020-05-26T10:42:27Z",
+      "lastSignedInAt": "2020-10-24T11:00:00Z"
+    },
+    "providerData": [
+      {
+        "email": "test@nowhere.com",
+        "providerId": "password",
+        "uid": "test@nowhere.com"
+      }
+    ],
+    "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+  },
+  "context": {
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "eventType": "providers/firebase.auth/eventTypes/user.create",
+    "resource": "projects/my-project-id",
+    "timestamp": "2020-09-29T11:32:00.123Z"
+  }
+}

--- a/invoker/core/src/test/resources/firebase-db1-cloudevent-input.json
+++ b/invoker/core/src/test/resources/firebase-db1-cloudevent-input.json
@@ -1,0 +1,15 @@
+{
+  "specversion": "1.0",
+  "type": "google.firebase.database.ref.v1.written",
+  "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+  "subject": "refs/gcf-test/xyz",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "data": null,
+    "delta": {
+      "grandchild": "other"
+    }
+  }
+}

--- a/invoker/core/src/test/resources/firebase-db1-legacy-output.json
+++ b/invoker/core/src/test/resources/firebase-db1-legacy-output.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "data": null,
+    "delta": {
+      "grandchild": "other"
+    }
+  },
+  "context": {
+    "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+    "timestamp": "2020-09-29T11:32:00.123Z",
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "eventType": "providers/google.firebase.database/eventTypes/ref.write" 
+  }
+}

--- a/invoker/core/src/test/resources/firebase-db2-cloudevent-input.json
+++ b/invoker/core/src/test/resources/firebase-db2-cloudevent-input.json
@@ -1,0 +1,17 @@
+{
+  "specversion": "1.0",
+  "type": "google.firebase.database.ref.v1.written",
+  "source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
+  "subject": "refs/gcf-test/xyz",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "data": {
+      "grandchild": "other"
+    },
+    "delta": {
+      "grandchild": "other changed"
+    }
+  }
+}

--- a/invoker/core/src/test/resources/firebase-db2-legacy-output.json
+++ b/invoker/core/src/test/resources/firebase-db2-legacy-output.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "data": {
+      "grandchild": "other"
+    },
+    "delta": {
+      "grandchild": "other changed"
+    }
+  },
+  "context": {
+    "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+    "timestamp": "2020-09-29T11:32:00.123Z",
+    "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
+  }
+}

--- a/invoker/core/src/test/resources/firestore_complex-cloudevent-input.json
+++ b/invoker/core/src/test/resources/firestore_complex-cloudevent-input.json
@@ -1,0 +1,80 @@
+{
+  "specversion": "1.0",
+  "type": "google.cloud.firestore.document.v1.written",
+  "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
+  "subject": "documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "oldValue": {},
+    "updateMask": {},
+    "value": {
+      "createTime": "2020-04-23T14:25:05.349632Z",
+      "fields": {
+        "arrayValue": {
+          "arrayValue": {
+            "values": [
+              {
+                "integerValue": "1"
+              },
+              {
+                "integerValue": "2"
+              }
+            ]
+          }
+        },
+        "booleanValue": {
+          "booleanValue": true
+        },
+        "doubleValue": {
+          "doubleValue": 5.5
+        },
+        "geoPointValue": {
+          "geoPointValue": {
+            "latitude": 51.4543,
+            "longitude": -0.9781
+          }
+        },
+        "intValue": {
+          "integerValue": "50"
+        },
+        "mapValue": {
+          "mapValue": {
+            "fields": {
+              "field1": {
+                "stringValue": "x"
+              },
+              "field2": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "stringValue": "x"
+                    },
+                    {
+                      "integerValue": "1"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "nullValue": {
+          "nullValue": null
+        },
+        "referenceValue": {
+          "referenceValue": "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"
+        },
+        "stringValue": {
+          "stringValue": "text"
+        },
+        "timestampValue": {
+          "timestampValue": "2020-04-23T14:23:53.241Z"
+        }
+      },
+      "name": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+      "updateTime": "2020-04-23T14:25:05.349632Z"
+    }
+  }
+}

--- a/invoker/core/src/test/resources/firestore_complex-legacy-output.json
+++ b/invoker/core/src/test/resources/firestore_complex-legacy-output.json
@@ -1,0 +1,79 @@
+{
+  "data": {
+    "oldValue": {},
+    "updateMask": {},
+    "value": {
+      "createTime": "2020-04-23T14:25:05.349632Z",
+      "fields": {
+        "arrayValue": {
+          "arrayValue": {
+            "values": [
+              {
+                "integerValue": "1"
+              },
+              {
+                "integerValue": "2"
+              }
+            ]
+          }
+        },
+        "booleanValue": {
+          "booleanValue": true
+        },
+        "doubleValue": {
+          "doubleValue": 5.5
+        },
+        "geoPointValue": {
+          "geoPointValue": {
+            "latitude": 51.4543,
+            "longitude": -0.9781
+          }
+        },
+        "intValue": {
+          "integerValue": "50"
+        },
+        "mapValue": {
+          "mapValue": {
+            "fields": {
+              "field1": {
+                "stringValue": "x"
+              },
+              "field2": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "stringValue": "x"
+                    },
+                    {
+                      "integerValue": "1"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "nullValue": {
+          "nullValue": null
+        },
+        "referenceValue": {
+          "referenceValue": "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"
+        },
+        "stringValue": {
+          "stringValue": "text"
+        },
+        "timestampValue": {
+          "timestampValue": "2020-04-23T14:23:53.241Z"
+        }
+      },
+      "name": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+      "updateTime": "2020-04-23T14:25:05.349632Z"
+    }
+  },
+  "context": {
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "eventType": "providers/cloud.firestore/eventTypes/document.write",
+    "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+    "timestamp": "2020-09-29T11:32:00.123Z"
+  }
+}

--- a/invoker/core/src/test/resources/pubsub_text-cloudevent-input.json
+++ b/invoker/core/src/test/resources/pubsub_text-cloudevent-input.json
@@ -1,0 +1,20 @@
+{
+  "specversion": "1.0",
+  "type": "google.cloud.pubsub.topic.v1.messagePublished",
+  "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "subscription": "projects/sample-project/subscriptions/sample-subscription",
+    "message": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+      "publishTime": "2020-09-29T11:32:00.123Z",
+      "attributes": {
+         "attr1":"attr1-value"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+    }
+  }
+}

--- a/invoker/core/src/test/resources/pubsub_text-legacy-output.json
+++ b/invoker/core/src/test/resources/pubsub_text-legacy-output.json
@@ -1,0 +1,19 @@
+{
+   "context": {
+      "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
+      "timestamp":"2020-09-29T11:32:00.123Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+         "attr1":"attr1-value"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+   }
+}

--- a/invoker/core/src/test/resources/storage-cloudevent-input.json
+++ b/invoker/core/src/test/resources/storage-cloudevent-input.json
@@ -1,0 +1,28 @@
+{
+  "specversion": "1.0",
+  "type": "google.cloud.storage.object.v1.finalized",
+  "source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+  "subject": "objects/folder/Test.cs",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "time": "2020-09-29T11:32:00.123Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "bucket": "some-bucket",
+    "contentType": "text/plain",
+    "crc32c": "rTVTeQ==",
+    "etag": "CNHZkbuF/ugCEAE=",
+    "generation": "1587627537231057",
+    "id": "some-bucket/folder/Test.cs/1587627537231057",
+    "kind": "storage#object",
+    "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+    "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+    "metageneration": "1",
+    "name": "folder/Test.cs",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+    "size": "352",
+    "storageClass": "MULTI_REGIONAL",
+    "timeCreated": "2020-04-23T07:38:57.230Z",
+    "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+    "updated": "2020-04-23T07:38:57.230Z"
+  }
+}

--- a/invoker/core/src/test/resources/storage-legacy-output.json
+++ b/invoker/core/src/test/resources/storage-legacy-output.json
@@ -1,0 +1,31 @@
+{
+   "context": {
+      "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+      "timestamp": "2020-09-29T11:32:00.123Z",
+      "eventType": "google.storage.object.finalize",
+      "resource": {
+         "service": "storage.googleapis.com",
+         "name": "projects/_/buckets/some-bucket/objects/folder/Test.cs",
+         "type": "storage#object"
+      }
+   },
+   "data": {
+      "bucket": "some-bucket",
+      "contentType": "text/plain",
+      "crc32c": "rTVTeQ==",
+      "etag": "CNHZkbuF/ugCEAE=",
+      "generation": "1587627537231057",
+      "id": "some-bucket/folder/Test.cs/1587627537231057",
+      "kind": "storage#object",
+      "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+      "metageneration": "1",
+      "name": "folder/Test.cs",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+      "size": "352",
+      "storageClass": "MULTI_REGIONAL",
+      "timeCreated": "2020-04-23T07:38:57.230Z",
+      "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+      "updated": "2020-04-23T07:38:57.230Z"
+   }
+}


### PR DESCRIPTION
This enables backwards compatability for GCF Background Functions with
newer CloudEvent-based eventing systems and brings FF Java up-to-date
with conformance tests.