### PR TITLE
chore: update kokoro build to restart gpg agent

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -10,6 +10,8 @@ setup_environment_secrets() {
   export GNUPGHOME=/tmp/gpg
   mkdir $GNUPGHOME
   mv ${KOKORO_KEYSTORE_DIR}/75669_functions-framework-java-release-bot-gpg-pubring $GNUPGHOME/pubring.kbx
+  # Restart the gpg-agent to avoid the error of no default secret key.
+  gpg -k
 }
 
 create_settings_xml_file() {


### PR DESCRIPTION
The kokoro run failed due to gpg error:

```
gpg: WARNING: unsafe permissions on homedir `/tmp/gpg'
gpg: keyring `/tmp/gpg/secring.gpg' created
gpg: keyring `/tmp/gpg/pubring.gpg' created
gpg: no default secret key: secret key not available
gpg: signing failed: secret key not available
```

This fix is ported from https://github.com/GoogleCloudPlatform/appengine-java-standard/blob/main/kokoro/gcp_ubuntu/release.sh#L27-L28