### PR TITLE
chore: don't list all keys in the gpg keybox

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -13,8 +13,6 @@ setup_environment_secrets() {
   export GNUPGHOME=/tmp/gpg
   mkdir $GNUPGHOME
   mv ${KOKORO_KEYSTORE_DIR}/75669_functions-framework-java-release-bot-gpg-pubring $GNUPGHOME/pubring.kbx
-  # Restart the gpg-agent to avoid the error of no default secret key.
-  gpg2 -k
 }
 
 create_settings_xml_file() {


### PR DESCRIPTION
Listing all keys exited with code 2 that broke the script.
```
gpg: WARNING: unsafe permissions on homedir '/tmp/gpg'
gpg: /tmp/gpg/trustdb.gpg: trustdb created
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
gpg: skipped packet of type 12 in keybox
/tmp/gpg/pubring.kbx
--------------------
...

[ID: 1064458] Command finished after 2 secs, exit value: 2
```