### PR TITLE
fix: bump jetty version to 9.4.49.v20220914

### DIFF
--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -97,12 +97,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.49.v20220914</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.49.v20220914</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>


### PR DESCRIPTION
Bump jetty version to be the same as GAE java runtimes: https://github.com/GoogleCloudPlatform/appengine-java-standard/blob/main/THIRD-PARTY.txt#L175-L196

fix #132