### PR TITLE
chore: add missing env variable to fix gpg error

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -5,6 +5,7 @@ set -e
 
 # Get secrets from keystore and set and environment variables.
 setup_environment_secrets() {
+  export GPG_TTY=$(tty)
   export SONATYPE_USERNAME=functions-framework-release-bot
   export SONATYPE_PASSWORD=$(cat ${KOKORO_KEYSTORE_DIR}/75669_functions-framework-java-release-bot-sonatype-password)
   export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)


### PR DESCRIPTION
Latest kokoro release failed with error:
```gpg: signing failed: Inappropriate ioctl for device```

According to https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html the env var ```GPG_TTY``` needs to be initialized to ```$(tty)```

Other sources:
1. https://unix.stackexchange.com/questions/257061/gentoo-linux-gpg-encrypts-properly-a-file-passed-through-parameter-but-throws-i/257065#257065
2. https://github.com/keybase/keybase-issues/issues/2798