### PR TITLE
chore: fix buildpack integration tests

### DIFF
--- a/invoker/conformance/buildpack_pom.xml
+++ b/invoker/conformance/buildpack_pom.xml
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>functions-framework-api</artifactId>
-      <version>0.0.0-SNAPSHOT</version>
+      <version>FRAMEWORK-API-VERSION</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.functions.invoker</groupId>
       <artifactId>java-function-invoker</artifactId>
-      <version>0.0.0-SNAPSHOT</version>
+      <version>INVOKER-VERSION</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
The buildpack integration tests were broken by the typed functions PR which introduces a dependency from the `invoker` package on the latest version of `function-framework-api`. 

The buildpack integration tests must build and install the latest versions of both of these packages and must also use the latest versions of the packages in the builder when running the buildpack integration tests. The prior strategy was to do this by installing the latest versions as a special 0.0.0-SNAPSHOT version which is used by the `.pom` file for the buildpack integration tests. Unfortunately, however, this version does not line up with the dependencies in the various components of function framework (i.e. transitive deps between local packages). To cover these cases we should instead use the real version and replace that version into the `.pom` file used by the buildpack integration tests.