### PR TITLE
fix: typed declaration works correctly with http trigger

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -51,6 +51,9 @@ jobs:
     - name: Build invoker with Maven
       run: (cd invoker/ && mvn install)
 
+    - name: Build invoker Maven Plugin
+      run: (cd function-maven-plugin/ && mvn install)
+
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -52,18 +52,28 @@ jobs:
       run: (cd invoker/ && mvn install)
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
-        version: 'v1.6.0'
+        version: 'v1.8.2'
         functionType: 'http'
         useBuildpacks: false
         cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.HttpConformanceFunction'"
         startDelay: 10
 
-    - name: Run background event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+    - name: Run Typed conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
-        version: 'v1.6.0'
+        version: 'v1.8.2'
+        functionType: 'http'
+        declarativeType: 'typed'
+        useBuildpacks: false
+        cmd: "'mvn -f invoker/conformance/pom.xml function:run -Drun.functionTarget=com.google.cloud.functions.conformance.TypedConformanceFunction'"
+        startDelay: 10
+
+    - name: Run background event conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      with:
+        version: 'v1.8.2'
         functionType: 'legacyevent'
         useBuildpacks: false
         validateMapping: true
@@ -71,9 +81,9 @@ jobs:
         startDelay: 10
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
-        version: 'v1.6.0'
+        version: 'v1.8.2'
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: true
@@ -81,9 +91,9 @@ jobs:
         startDelay: 10
 
     - name: Run HTTP concurrency conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
-        version: 'v1.6.0'
+        version: 'v1.8.2'
         functionType: 'http'
         useBuildpacks: false
         validateConcurrency: true

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>functions-framework-api</artifactId>
+      <version>1.1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -52,7 +53,7 @@
         <plugin>
           <groupId>com.google.cloud.functions</groupId>
           <artifactId>function-maven-plugin</artifactId>
-          <version>0.10.1</version>
+          <version>0.11.1-SNAPSHOT</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
@@ -1,0 +1,19 @@
+package com.google.cloud.functions.conformance;
+
+import com.google.cloud.functions.TypedFunction;
+import com.google.gson.JsonObject;
+
+public class TypedConformanceFunction implements TypedFunction<JsonObject, ConformanceResponse> {
+  @Override
+  public ConformanceResponse apply(JsonObject req) throws Exception {
+    return new ConformanceResponse(req);
+  }
+}
+
+class ConformanceResponse {
+  JsonObject payload = null;
+
+  ConformanceResponse(JsonObject payload) {
+    this.payload = payload;
+  }
+}

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
@@ -3,7 +3,8 @@ package com.google.cloud.functions.conformance;
 import com.google.cloud.functions.TypedFunction;
 import com.google.gson.annotations.SerializedName;
 
-public class TypedConformanceFunction implements TypedFunction<ConformanceRequest, ConformanceResponse> {
+public class TypedConformanceFunction
+    implements TypedFunction<ConformanceRequest, ConformanceResponse> {
   @Override
   public ConformanceResponse apply(ConformanceRequest req) throws Exception {
     return new ConformanceResponse(req);

--- a/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
+++ b/invoker/conformance/src/main/java/com/google/cloud/functions/conformance/TypedConformanceFunction.java
@@ -1,19 +1,25 @@
 package com.google.cloud.functions.conformance;
 
 import com.google.cloud.functions.TypedFunction;
-import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
 
-public class TypedConformanceFunction implements TypedFunction<JsonObject, ConformanceResponse> {
+public class TypedConformanceFunction implements TypedFunction<ConformanceRequest, ConformanceResponse> {
   @Override
-  public ConformanceResponse apply(JsonObject req) throws Exception {
+  public ConformanceResponse apply(ConformanceRequest req) throws Exception {
     return new ConformanceResponse(req);
   }
 }
 
-class ConformanceResponse {
-  JsonObject payload = null;
+class ConformanceRequest {
+  @SerializedName("message")
+  public String message;
+}
 
-  ConformanceResponse(JsonObject payload) {
+class ConformanceResponse {
+  @SerializedName("payload")
+  public ConformanceRequest payload = null;
+
+  ConformanceResponse(ConformanceRequest payload) {
     this.payload = payload;
   }
 }

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -299,7 +299,11 @@ public class Invoker {
     } else {
       switch (functionSignatureType) {
         case "http":
-          servlet = HttpFunctionExecutor.forClass(functionClass);
+          if (TypedFunction.class.isAssignableFrom(functionClass)) {
+            servlet = TypedFunctionExecutor.forClass(functionClass);
+          } else {
+            servlet = HttpFunctionExecutor.forClass(functionClass);
+          }
           break;
         case "event":
         case "cloudevent":


### PR DESCRIPTION
 * Makes typed functions compatible with HTTP triggers by updating Invoker to select a `TypedFunctionExecutor` if the signature is `http` and `TypedFunction` interface. This allows `typed` functions to be used on Google Cloud in the place of `http` functions without changing the trigger type.
 *  Adds conformance test coverage.