### PR TITLE
ci: fix function-maven-plugin release

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -1,6 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+  </parent>
+
   <groupId>com.google.cloud.functions</groupId>
   <artifactId>function-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
@@ -16,6 +22,14 @@
     <developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/functions-framework-java.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Developer and license information was missing from the pom and is required to publish to the Maven central repo.