### PR TITLE
fix(functions): include Implementation-Version key in invoker jar manifest

### DIFF
--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -165,6 +165,8 @@
           <archive>
             <manifest>
               <mainClass>com.google.cloud.functions.invoker.runner.Invoker</mainClass>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
           </archive>
         </configuration>


### PR DESCRIPTION
Update invoker manifest to set the `Implementation-Version` key on the generated Jar file. See https://maven.apache.org/shared/maven-archiver/examples/manifest.html