### PR TITLE
fix: avoid executing function when /favicon.ico or /robots.txt is called

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -474,6 +474,7 @@ public class Invoker {
         throws IOException, ServletException {
       if (NOT_FOUND_PATHS.contains(request.getRequestURI())) {
         response.sendError(HttpStatus.NOT_FOUND_404, "Not Found");
+        return;
       }
       super.handle(target, baseRequest, request, response);
     }


### PR DESCRIPTION
Proposed change to fix https://github.com/GoogleCloudPlatform/functions-framework-java/issues/225.

As explained in the issue, the solution is based on other Jetty handlers: [InetAccessHandler.java](https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java#L212-L229)


Regarding tests, the integration tests were passing because they just check that 404 is returned, but they miss to check that function is not invoked.

I think that an extra test checking that part would be nice, but the current test framework API won't let me easily check that. I may extend a bit the test framework to add this test if you agree.