### PR TITLE
Revert "chore(main): release java-function-invoker 1.3.1"

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"functions-framework-api":"1.1.0","invoker":"1.3.1","function-maven-plugin":"0.11.0"}
+{"functions-framework-api":"1.1.0","invoker":"1.3.0","function-maven-plugin":"0.11.0"}

--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.google.cloud.functions.invoker</groupId>
       <artifactId>java-function-invoker</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/invoker/CHANGELOG.md
+++ b/invoker/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [1.3.1](https://github.com/GoogleCloudPlatform/functions-framework-java/compare/java-function-invoker-v1.3.0...java-function-invoker-v1.3.1) (2023-09-13)
-
-
-### Bug Fixes
-
-* **functions:** include Implementation-Version key in invoker package manifest ([#221](https://github.com/GoogleCloudPlatform/functions-framework-java/issues/221)) ([f3fe2ce](https://github.com/GoogleCloudPlatform/functions-framework-java/commit/f3fe2ce46fcb1885137cdf504649612e7c31dc4c))
-* typed declaration works correctly with http trigger ([#212](https://github.com/GoogleCloudPlatform/functions-framework-java/issues/212)) ([b3045ad](https://github.com/GoogleCloudPlatform/functions-framework-java/commit/b3045ad380cd23e37f5edec0d758031438bcb568))
-
 ## [1.3.0](https://github.com/GoogleCloudPlatform/functions-framework-java/compare/java-function-invoker-v1.2.1...java-function-invoker-v1.3.0) (2023-06-01)
 
 

--- a/invoker/conformance/pom.xml
+++ b/invoker/conformance/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>java-function-invoker-parent</artifactId>
     <groupId>com.google.cloud.functions.invoker</groupId>
-    <version>1.3.1</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>com.google.cloud.functions.invoker</groupId>
   <artifactId>conformance</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.1-SNAPSHOT</version>
 
   <name>GCF Confromance Tests</name>
   <description>

--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.cloud.functions.invoker</groupId>
     <artifactId>java-function-invoker-parent</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>com.google.cloud.functions.invoker</groupId>
   <artifactId>java-function-invoker</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>GCF Java Invoker</name>
   <description>
     Application that invokes a GCF Java function. This application is a
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.google.cloud.functions.invoker</groupId>
       <artifactId>java-function-invoker-testfunction</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.google.cloud.functions.invoker</groupId>
   <artifactId>java-function-invoker-parent</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>GCF Java Invoker Parent</name>
   <description>

--- a/invoker/testfunction/pom.xml
+++ b/invoker/testfunction/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.cloud.functions.invoker</groupId>
     <artifactId>java-function-invoker-parent</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>com.google.cloud.functions.invoker</groupId>
   <artifactId>java-function-invoker-testfunction</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>Example GCF Function Jar</name>
   <description>
     An example of a GCF function packaged into a jar. We use this in tests.


### PR DESCRIPTION
Reverts GoogleCloudPlatform/functions-framework-java#220

Release failed due to missing version updates in the conformance.pom manifest, reverting to reattempt release.