### PR TITLE
fix: set Thread Context ClassLoader correctly when invoking handler constructor

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/HttpFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/HttpFunctionExecutor.java
@@ -48,12 +48,16 @@ public class HttpFunctionExecutor extends HttpServlet {
               + HttpFunction.class.getName());
     }
     Class<? extends HttpFunction> httpFunctionClass = functionClass.asSubclass(HttpFunction.class);
+    ClassLoader oldContextLoader = Thread.currentThread().getContextClassLoader();
     try {
+      Thread.currentThread().setContextClassLoader(httpFunctionClass.getClassLoader());
       HttpFunction httpFunction = httpFunctionClass.getConstructor().newInstance();
       return new HttpFunctionExecutor(httpFunction);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(
           "Could not construct an instance of " + functionClass.getName() + ": " + e, e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(oldContextLoader);
     }
   }
 

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/HttpFunctionExecutorTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/HttpFunctionExecutorTest.java
@@ -1,0 +1,36 @@
+package com.google.cloud.functions.invoker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HttpFunctionExecutorTest {
+  private static ClassLoader customClassLoader =
+      new ClassLoader(ClassLoader.getSystemClassLoader()) {};
+
+  public static class ClassLoaderVerifier implements HttpFunction {
+    public ClassLoaderVerifier() {
+      assertThat(Thread.currentThread().getContextClassLoader())
+          .isNotSameInstanceAs(customClassLoader);
+    }
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+  }
+
+  @Test
+  public void usesCorrectClassLoaderOverride() {
+    ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(customClassLoader);
+    HttpFunctionExecutor.forClass(ClassLoaderVerifier.class);
+    Thread.currentThread().setContextClassLoader(oldClassLoader);
+  }
+}


### PR DESCRIPTION
Adds the same logic that is used to set the Thread Context ClassLoader when handling a request to also apply that same class loader when constructing the handler. 

Addresses issue https://github.com/GoogleCloudPlatform/functions-framework-java/issues/110