### PR TITLE
fix: server times out when specified by CLOUD_RUN_TIMEOUT_SECONDS

### DIFF
--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -102,6 +102,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <version>9.4.54.v20240208</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>9.4.54.v20240208</version>
     </dependency>

--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -102,11 +102,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlets</artifactId>
-      <version>9.4.54.v20240208</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>9.4.54.v20240208</version>
     </dependency>

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
@@ -1,0 +1,73 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.functions.invoker.http;
+
+import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class TimeoutFilter implements Filter {
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30; // Default timeout in seconds
+  private final int timeoutMs;
+
+  public TimeoutFilter() {
+    this(DEFAULT_TIMEOUT_SECONDS);
+  }
+
+  public TimeoutFilter(int timeoutSeconds) {
+    this.timeoutMs = timeoutSeconds * 1000; // Convert seconds to milliseconds
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    Timer timer = new Timer(true);
+    TimerTask timeoutTask =
+        new TimerTask() {
+          @Override
+          public void run() {
+            if (response instanceof HttpServletResponse) {
+              try {
+                ((HttpServletResponse) response)
+                    .sendError(HttpServletResponse.SC_REQUEST_TIMEOUT, "Request timed out");
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            } else {
+              try {
+                response.getWriter().write("Request timed out");
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            }
+          }
+        };
+
+    timer.schedule(timeoutTask, timeoutMs);
+
+    try {
+      chain.doFilter(request, response);
+      timeoutTask.cancel();
+    } finally {
+      timer.purge();
+    }
+  }
+}

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
@@ -47,13 +47,13 @@ public class TimeoutFilter implements Filter {
                 ((HttpServletResponse) response)
                     .sendError(HttpServletResponse.SC_REQUEST_TIMEOUT, "Request timed out");
               } catch (IOException e) {
-                logger.warning("Error while sending HTTP response " + e.toString());
+                logger.warning("Error while sending HTTP response: " + e.toString());
               }
             } else {
               try {
                 response.getWriter().write("Request timed out");
               } catch (IOException e) {
-                logger.warning("Error while writing response " + e.toString());
+                logger.warning("Error while writing response: " + e.toString());
               }
             }
           }

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/http/TimeoutFilter.java
@@ -17,6 +17,7 @@ package com.google.cloud.functions.invoker.http;
 import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.logging.Logger;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -25,12 +26,9 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
 public class TimeoutFilter implements Filter {
-  private static final int DEFAULT_TIMEOUT_SECONDS = 30; // Default timeout in seconds
-  private final int timeoutMs;
 
-  public TimeoutFilter() {
-    this(DEFAULT_TIMEOUT_SECONDS);
-  }
+  private static final Logger logger = Logger.getLogger(TimeoutFilter.class.getName());
+  private final int timeoutMs;
 
   public TimeoutFilter(int timeoutSeconds) {
     this.timeoutMs = timeoutSeconds * 1000; // Convert seconds to milliseconds
@@ -49,13 +47,13 @@ public class TimeoutFilter implements Filter {
                 ((HttpServletResponse) response)
                     .sendError(HttpServletResponse.SC_REQUEST_TIMEOUT, "Request timed out");
               } catch (IOException e) {
-                e.printStackTrace();
+                logger.warning("Error while sending HTTP response " + e.toString());
               }
             } else {
               try {
                 response.getWriter().write("Request timed out");
               } catch (IOException e) {
-                e.printStackTrace();
+                logger.warning("Error while writing response " + e.toString());
               }
             }
           }

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -51,6 +51,7 @@ import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -253,6 +254,34 @@ public class IntegrationTest {
   }
 
   @Test
+  public void timeoutHttpSuccess() throws Exception {
+    testFunction(
+        SignatureType.HTTP,
+        fullTarget("TimeoutHttp"),
+        ImmutableList.of(),
+        ImmutableList.of(
+            TestCase.builder()
+            .setExpectedResponseText("finished\n")
+            .setExpectedResponseText(Optional.empty())
+            .build()),
+        ImmutableMap.of("CLOUD_RUN_TIMEOUT_SECONDS", "3"));
+  }
+
+  @Test
+  public void timeoutHttpTimesOut() throws Exception {
+    testFunction(
+        SignatureType.HTTP,
+        fullTarget("TimeoutHttp"),
+        ImmutableList.of(),
+            ImmutableList.of(
+            TestCase.builder()
+            .setExpectedResponseCode(408)
+            .setExpectedResponseText(Optional.empty())
+            .build()),
+        ImmutableMap.of("CLOUD_RUN_TIMEOUT_SECONDS", "1"));
+  }
+
+  @Test
   public void exceptionHttp() throws Exception {
     String exceptionExpectedOutput =
         "\"severity\": \"ERROR\", \"logging.googleapis.com/sourceLocation\": {\"file\":"
@@ -290,7 +319,8 @@ public class IntegrationTest {
                 .setRequestText(gcfRequestText)
                 .setExpectedResponseCode(500)
                 .setExpectedOutput(exceptionExpectedOutput)
-                .build()));
+                .build()),
+        Collections.emptyMap());
   }
 
   @Test
@@ -400,7 +430,8 @@ public class IntegrationTest {
             TestCase.builder()
                 .setRequestText(originalJson)
                 .setExpectedResponseText("{\"fullName\":\"JohnDoe\"}")
-                .build()));
+                .build()),
+        Collections.emptyMap());
   }
 
   @Test
@@ -410,7 +441,8 @@ public class IntegrationTest {
         fullTarget("TypedVoid"),
         ImmutableList.of(),
         ImmutableList.of(
-            TestCase.builder().setRequestText("{}").setExpectedResponseCode(204).build()));
+            TestCase.builder().setRequestText("{}").setExpectedResponseCode(204).build()),
+        Collections.emptyMap());
   }
 
   @Test
@@ -424,7 +456,8 @@ public class IntegrationTest {
                 .setRequestText("abc\n123\n$#@\n")
                 .setExpectedResponseText("abc123$#@")
                 .setExpectedResponseCode(200)
-                .build()));
+                .build()),
+        Collections.emptyMap());
   }
 
   private void backgroundTest(String target) throws Exception {
@@ -595,7 +628,8 @@ public class IntegrationTest {
         SignatureType.HTTP,
         "com.example.functionjar.Foreground",
         ImmutableList.of("--classpath", functionJarString()),
-        ImmutableList.of(testCase));
+        ImmutableList.of(testCase),
+        Collections.emptyMap());
   }
 
   /** Like {@link #classpathOptionHttp} but for background functions. */
@@ -612,7 +646,8 @@ public class IntegrationTest {
         SignatureType.BACKGROUND,
         "com.example.functionjar.Background",
         ImmutableList.of("--classpath", functionJarString()),
-        ImmutableList.of(TestCase.builder().setRequestText(json.toString()).build()));
+        ImmutableList.of(TestCase.builder().setRequestText(json.toString()).build()),
+        Collections.emptyMap());
   }
 
   /** Like {@link #classpathOptionHttp} but for typed functions. */
@@ -629,7 +664,8 @@ public class IntegrationTest {
             TestCase.builder()
                 .setRequestText(originalJson)
                 .setExpectedResponseText("{\"fullName\":\"JohnDoe\"}")
-                .build()));
+                .build()),
+        Collections.emptyMap());
   }
 
   // In these tests, we test a number of different functions that express the same functionality
@@ -643,7 +679,12 @@ public class IntegrationTest {
     for (TestCase testCase : testCases) {
       File snoopFile = testCase.snoopFile().get();
       snoopFile.delete();
-      testFunction(signatureType, functionTarget, ImmutableList.of(), ImmutableList.of(testCase));
+      testFunction(
+          signatureType,
+          functionTarget,
+          ImmutableList.of(),
+          ImmutableList.of(testCase),
+          Collections.emptyMap());
       String snooped = new String(Files.readAllBytes(snoopFile.toPath()), StandardCharsets.UTF_8);
       Gson gson = new Gson();
       JsonObject snoopedJson = gson.fromJson(snooped, JsonObject.class);
@@ -667,16 +708,18 @@ public class IntegrationTest {
   }
 
   private void testHttpFunction(String target, List<TestCase> testCases) throws Exception {
-    testFunction(SignatureType.HTTP, target, ImmutableList.of(), testCases);
+    testFunction(SignatureType.HTTP, target, ImmutableList.of(), testCases, Collections.emptyMap());
   }
 
   private void testFunction(
       SignatureType signatureType,
       String target,
       ImmutableList<String> extraArgs,
-      List<TestCase> testCases)
+      List<TestCase> testCases,
+      Map<String, String> environmentVariables)
       throws Exception {
-    ServerProcess serverProcess = startServer(signatureType, target, extraArgs);
+    ServerProcess serverProcess =
+        startServer(signatureType, target, extraArgs, environmentVariables);
     try {
       HttpClient httpClient = new HttpClient();
       httpClient.start();
@@ -772,7 +815,10 @@ public class IntegrationTest {
   }
 
   private ServerProcess startServer(
-      SignatureType signatureType, String target, ImmutableList<String> extraArgs)
+      SignatureType signatureType,
+      String target,
+      ImmutableList<String> extraArgs,
+      Map<String, String> environmentVariables)
       throws IOException, InterruptedException {
     File javaHome = new File(System.getProperty("java.home"));
     assertThat(javaHome.exists()).isTrue();
@@ -798,6 +844,7 @@ public class IntegrationTest {
             "FUNCTION_TARGET",
             target);
     processBuilder.environment().putAll(environment);
+    processBuilder.environment().putAll(environmentVariables);
     Process serverProcess = processBuilder.start();
     CountDownLatch ready = new CountDownLatch(1);
     StringBuilder output = new StringBuilder();

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/IntegrationTest.java
@@ -261,9 +261,9 @@ public class IntegrationTest {
         ImmutableList.of(),
         ImmutableList.of(
             TestCase.builder()
-            .setExpectedResponseText("finished\n")
-            .setExpectedResponseText(Optional.empty())
-            .build()),
+                .setExpectedResponseText("finished\n")
+                .setExpectedResponseText(Optional.empty())
+                .build()),
         ImmutableMap.of("CLOUD_RUN_TIMEOUT_SECONDS", "3"));
   }
 
@@ -273,11 +273,11 @@ public class IntegrationTest {
         SignatureType.HTTP,
         fullTarget("TimeoutHttp"),
         ImmutableList.of(),
-            ImmutableList.of(
+        ImmutableList.of(
             TestCase.builder()
-            .setExpectedResponseCode(408)
-            .setExpectedResponseText(Optional.empty())
-            .build()),
+                .setExpectedResponseCode(408)
+                .setExpectedResponseText(Optional.empty())
+                .build()),
         ImmutableMap.of("CLOUD_RUN_TIMEOUT_SECONDS", "1"));
   }
 

--- a/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/TimeoutHttp.java
+++ b/invoker/core/src/test/java/com/google/cloud/functions/invoker/testfunctions/TimeoutHttp.java
@@ -1,0 +1,18 @@
+package com.google.cloud.functions.invoker.testfunctions;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+public class TimeoutHttp implements HttpFunction {
+
+  @Override
+  public void service(HttpRequest request, HttpResponse response) throws Exception {
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      response.getWriter().close();
+    }
+    response.getWriter().write("finished\n");
+  }
+}


### PR DESCRIPTION
* feature: adds timeout limit to jetty server specified by CLOUD_RUN_TIMEOUT_SECONDS
* adds test coverage