### PR TITLE
fix: revert maven-source-plugin to 3.2.1

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -3,6 +3,16 @@
 # Stop execution when any command fails.
 set -e
 
+# update the Maven version to 3.6.3
+pushd /usr/local
+wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz
+tar -xvzf apache-maven-3.6.3-bin.tar.gz apache-maven-3.6.3
+rm -f /usr/local/apache-maven
+ln -s /usr/local/apache-maven-3.6.3 /usr/local/apache-maven
+rm apache-maven-3.6.3-bin.tar.gz
+popd
+
+
 # Get secrets from keystore and set and environment variables.
 setup_environment_secrets() {
   export GPG_TTY=$(tty)

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>3.6.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>com.google.cloud.functions</groupId>
   <artifactId>functions-framework-api</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>


### PR DESCRIPTION
there are two maven-source-plugin specified. I think we ran into the same issue as https://stackoverflow.com/questions/76305897/maven-build-fails-after-upgrading-to-maven-source-plugin-from-3-2-1-to-3-3-0

I am not familiar with Java enough, so decide to just revert it to an old version in the last 1.1.0 release