### PR TITLE
fix: correct release-please-config for invoker/conformance/pom.xml

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -48,11 +48,6 @@
                 },
                 {
                     "type": "xml",
-                    "path": "conformance/pom.xml",
-                    "xpath": "//*[local-name()='artifactId' and text()='function-maven-plugin']/parent::*/*[local-name()='version']" 
-                },
-                {
-                    "type": "xml",
                     "path": "testfunction/pom.xml",
                     "xpath": "//*[local-name()='artifactId' and text()='java-function-invoker-parent']/parent::*/*[local-name()='version']"
                 },


### PR DESCRIPTION
Previous change d31b502 incorrectly added an extra file to the invoker release which is causing automation breakages when the invoker release PRs are created. 

Example of a broken release PR: https://github.com/GoogleCloudPlatform/functions-framework-java/pull/321/commits

Remove config from version bumping.