### PR TITLE
fix: correct Cloud Event retry functionality

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/BackgroundFunctionExecutor.java
@@ -364,14 +364,7 @@ public final class BackgroundFunctionExecutor extends HttpServlet {
     // ServiceLoader.load
     // will throw ServiceConfigurationError. At this point we're still running with the default
     // context ClassLoader, which is the system ClassLoader that has loaded the code here.
-    try {
-      executionIdUtil.storeExecutionId(req);
-      runWithContextClassLoader(() -> executor.serviceCloudEvent(reader.toEvent(data -> data)));
-    } catch (Throwable t) {
-      logger.log(Level.SEVERE, "Failed to execute " + executor.functionName(), t);
-    } finally {
-      executionIdUtil.removeExecutionId();
-    }
+    runWithContextClassLoader(() -> executor.serviceCloudEvent(reader.toEvent(data -> data)));
     // The data->data is a workaround for a bug fixed since Milestone 4 of the SDK, in
     // https://github.com/cloudevents/sdk-java/pull/259.
   }

--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/gcf/JsonLogHandler.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/gcf/JsonLogHandler.java
@@ -17,6 +17,7 @@ import java.util.logging.LogRecord;
  */
 public final class JsonLogHandler extends Handler {
   private static final String SOURCE_LOCATION_KEY = "\"logging.googleapis.com/sourceLocation\": ";
+  private static final String LOG_EXECUTION_ID_ENV_NAME = "LOG_EXECUTION_ID";
 
   private static final String DEBUG = "DEBUG";
   private static final String INFO = "INFO";
@@ -108,9 +109,11 @@ public final class JsonLogHandler extends Handler {
   }
 
   private void appendExecutionId(StringBuilder json, LogRecord record) {
-    json.append("\"execution_id\": \"")
-        .append(executionIdByThreadMap.get(Integer.toString(record.getThreadID())))
-        .append("\", ");
+    if (executionIdLoggingEnabled()) {
+      json.append("\"execution_id\": \"")
+          .append(executionIdByThreadMap.get(Integer.toString(record.getThreadID())))
+          .append("\", ");
+    }
   }
 
   private static String escapeString(String s) {
@@ -141,5 +144,9 @@ public final class JsonLogHandler extends Handler {
 
   public void removeExecutionId(long threadId) {
     executionIdByThreadMap.remove(Long.toString(threadId));
+  }
+
+  private boolean executionIdLoggingEnabled() {
+    return Boolean.parseBoolean(System.getenv().getOrDefault(LOG_EXECUTION_ID_ENV_NAME, "false"));
   }
 }


### PR DESCRIPTION
An unnecessary try-catch masked function exceptions and resulted in success response codes even when a function threw. Remove try-catch and add a test case to cover this path for CloudEvents to avoid regression. (Prior tests only covered Legacy event exceptions).