### PR TITLE
Add a warning when an entry provided with "--classpath" does not exists

### DIFF
--- a/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
+++ b/invoker/core/src/main/java/com/google/cloud/functions/invoker/runner/Invoker.java
@@ -418,6 +418,9 @@ public class Invoker {
         urls.addAll(jarsIn(component.substring(0, component.length() - 2)));
       } else {
         Path path = Paths.get(component);
+        if(!Files.isRegularFile(path)) {
+          logger.log(Level.WARNING, "Classpath entry '" + path + "' does not exist");
+        }
         try {
           urls.add(path.toUri().toURL());
         } catch (MalformedURLException e) {


### PR DESCRIPTION
I lost a lot of time because I had a typo in the jar listed as `--classpath` value when running the command:

```
java -jar java-function-invoker-<version>.jar \
  --classpath build/my-function-1.0.0-SNAPSHOT-runner.jar \
  --target io.quarkus.gcp.functions.QuarkusHttpFunction
```

I think it would make sense to add a warning to help users (like me) realizing they added an invalid entry on the list provided with `--classpath`.