### PR TITLE
fix: several minor fixes

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -42,11 +42,13 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.9.11</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>3.9.11</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/DeployFunction.java
+++ b/function-maven-plugin/src/main/java/com/google/cloud/functions/plugin/DeployFunction.java
@@ -63,9 +63,8 @@ public class DeployFunction extends CloudSdkMojo {
    */
   @Parameter(
       alias = "deploy.allowunauthenticated",
-      property = "function.deploy.allowunauthenticated",
-      defaultValue = "false")
-  boolean allowUnauthenticated;
+      property = "function.deploy.allowunauthenticated")
+  Boolean allowUnauthenticated;
 
   /**
    * Name of a Google Cloud Function (as defined in source code) that will be executed. Defaults to
@@ -314,8 +313,12 @@ public class DeployFunction extends CloudSdkMojo {
     if (triggerEvent != null) {
       commands.add("--trigger-event=" + triggerEvent);
     }
-    if (allowUnauthenticated) {
-      commands.add("--allow-unauthenticated");
+    if (allowUnauthenticated != null) {
+      if (allowUnauthenticated) {
+        commands.add("--allow-unauthenticated");
+      } else {
+        commands.add("--no-allow-unauthenticated");
+      }
     }
     if (functionTarget != null) {
       commands.add("--entry-point=" + functionTarget);
@@ -371,6 +374,8 @@ public class DeployFunction extends CloudSdkMojo {
     if (projectId != null) {
       commands.add("--project=" + projectId);
     }
+
+    commands.add("--quiet");
     return Collections.unmodifiableList(commands);
   }
 
@@ -382,7 +387,8 @@ public class DeployFunction extends CloudSdkMojo {
       System.out.println("Executing Cloud SDK command: gcloud " + String.join(" ", params));
       gcloud.runCommand(params);
     } catch (CloudSdkNotFoundException | IOException | ProcessHandlerException ex) {
-      Logger.getLogger(DeployFunction.class.getName()).log(Level.SEVERE, null, ex);
+      Logger.getLogger(DeployFunction.class.getName()).log(Level.SEVERE, "Function deployment failed", ex);
+      throw new MojoExecutionException("Function deployment failed", ex);
     }
   }
 }

--- a/function-maven-plugin/src/test/java/com/google/cloud/functions/plugin/DeployFunctionTest.java
+++ b/function-maven-plugin/src/test/java/com/google/cloud/functions/plugin/DeployFunctionTest.java
@@ -53,7 +53,8 @@ public class DeployFunctionTest {
             "--env-vars-file=myfile",
             "--set-build-env-vars=env1=a,env2=b",
             "--build-env-vars-file=myfile2",
-            "--runtime=java11");
+            "--runtime=java11",
+            "--quiet");
     assertThat(mojo.getCommands()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
Changed a couple of maven plugins's scope to provided as recommended by Maven.

Fixed #117: during first deploy unless the allowUnauthenticated property was set to true, the gcloud command was waiting on a prompt that was not visible and could not be interacted with. This change removes the allowUnauthenticated property's default value and relies on gcloud's behavior which will default this value to false if prompting is turned off with '--quiet'. If the allowUnauthenticated is explicitly set, it will correctly append the --[no-]allow-unauthenticated flag to the command.

If the gcloud command fails, the plugin will not report a successful build.