### PR TITLE
build: Override central-publishing-maven-plugin guava dependency to 33.5.0-jre

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -170,6 +170,13 @@
               <publishingServerId>sonatype-central-portal</publishingServerId>
               <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.5.0-jre</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -203,6 +203,13 @@
               <publishingServerId>sonatype-central-portal</publishingServerId>
               <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.5.0-jre</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -136,6 +136,13 @@
               <publishingServerId>sonatype-central-portal</publishingServerId>
               <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.5.0-jre</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
When running in secure build environments or behind private package mirrors, older transitive dependencies of `central-publishing-maven-plugin` (`guava:32.1.0-jre`) may fail to resolve or be unavailable.

This explicitly overrides the plugin's transitive dependency to use `guava:33.5.0-jre` (which is already vetted and used by the project), ensuring reliable dependency resolution across all build environments.