### PR TITLE
build: override maven-enforcer-plugin version to 3.6.3

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -100,6 +100,15 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -75,6 +75,15 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -82,6 +82,17 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
   <profiles>
     <profile>
       <id>sonatype-oss-release</id>


### PR DESCRIPTION
In secure build environments or behind private package mirrors, ancient Maven plugins from 2012 (like maven-enforcer-plugin:1.2 inherited from oss-parent:9) fail because they rely on obsolete Plexus container libraries from 2006 that are unavailable.

This overrides maven-enforcer-plugin to use modern version 3.6.3 across all modules, ensuring reliable build environment validation across all systems.