### PR TITLE
fix: enforce maven-enforcer-plugin 3.6.3 in release profile and fix POM structure

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -132,6 +132,11 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.3</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <version>3.2.1</version>
             <executions>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -161,6 +161,11 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.3</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <version>3.2.1</version>
             <executions>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -75,15 +75,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.3</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -129,6 +120,11 @@
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -100,6 +100,11 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.3</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <version>3.2.1</version>
             <executions>


### PR DESCRIPTION
When release builds activate the `sonatype-oss-release` profile inherited from `oss-parent:9`, Maven executes `maven-enforcer-plugin:1.2` declared in the parent profile's plugins block, overriding root-level `pluginManagement`.

This PR:
1. Explicitly declares `maven-enforcer-plugin:3.6.3` inside the `sonatype-oss-release` profile across all modules, guaranteeing modern plugin execution during automated release builds.
2. Cleanly merges `pluginManagement` blocks in `functions-framework-api/pom.xml` to resolve duplicate tag parse errors and ensure valid POM XML structure.