### PR TITLE
build: set maven-enforcer-plugin to 3.5.0 for offline mirror compatibility

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -105,7 +105,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -133,7 +133,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.6.3</version>
+            <version>3.5.0</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -123,7 +123,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
@@ -162,7 +162,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.6.3</version>
+            <version>3.5.0</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -88,7 +88,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -101,7 +101,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.6.3</version>
+            <version>3.5.0</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
During automated release builds in secure, offline environments, Maven failed with a transitive dependency resolution error:
`Could not find artifact org.apache.maven:maven-parent:pom:48 in mirror`

In secure release pipelines, all Maven dependencies must be resolved through an internal vetted package mirror. While `maven-enforcer-plugin:3.6.3` exists in the mirror, its parent POM (`org.apache.maven:maven-parent:48`) is currently unavailable in the offline cache.

An audit of our package mirror confirmed that `org.apache.maven:maven-parent:42` is fully cached and available. By setting `maven-enforcer-plugin` to **`3.5.0`** (the highest modern version that inherits from `maven-parent:42`), we maintain a modern Enforcer plugin while guaranteeing 100% offline mirror compatibility during automated release builds.