### PR TITLE
build: set maven-install-plugin to 3.1.2 for offline mirror compatibility

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -107,6 +107,11 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -126,6 +126,11 @@
           <version>3.5.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -90,6 +90,11 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
During automated release builds in secure, offline environments, Maven failed with a transitive dependency resolution error:
`Could not find artifact org.codehaus.plexus:plexus-components:pom:1.1.7 in mirror`

When building against Sonatype's `oss-parent:9`, default lifecycle bindings execute `maven-install-plugin:2.4` (from 2012), which depends on deprecated Plexus artifacts that are unavailable in offline package mirrors.

An audit of our package mirror confirmed that `maven-install-plugin:3.1.2` (and its parent POM tree) is fully cached and available. By explicitly defining version **`3.1.2`** in root `pluginManagement`, we resolve the missing artifact error while keeping changes minimal and surgical.