### PR TITLE
ci: set JAVA_HOME to OpenJDK 17 in Kokoro build script

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -6,6 +6,12 @@ REPO_DIR="${KOKORO_ARTIFACTS_DIR}/git/functions-framework-java"
 cd "${REPO_DIR}"
 
 # ==============================================================================
+# 0. Set up Java 17 Environment
+# ==============================================================================
+export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+export PATH="${JAVA_HOME}/bin:${PATH}"
+
+# ==============================================================================
 # 1. Configure Airlock and AR Credentials
 # ==============================================================================
 # Get OAuth token from GCE metadata server inside Kokoro VM


### PR DESCRIPTION
When compiling modules that require Java 17 bytecode (e.g., `invoker/testfunction`), `javac` failed with:
`Fatal error compiling: error: invalid target release: 17`

By default, Kokoro's `ubuntu2204/full` build container runs with `JAVA_HOME` pointing to OpenJDK 11 unless explicitly configured. This PR sets `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64` and updates `PATH` at the top of `.kokoro/build.sh`, ensuring Maven executes using OpenJDK 17 to match the repository's configured compiler target.