### PR TITLE
build: remove deprecated and unused truth-java8-extension from invoker/core

### DIFF
--- a/invoker/core/pom.xml
+++ b/invoker/core/pom.xml
@@ -140,12 +140,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.truth.extensions</groupId>
-      <artifactId>truth-java8-extension</artifactId>
-      <version>1.4.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <version>${jetty.version}</version>


### PR DESCRIPTION
During offline release validation builds (`invoker/core`), Maven failed to resolve test dependencies:
`Could not find artifact com.google.truth.extensions:truth-java8-extension:jar:1.4.5 in mirror`

`truth-java8-extension` is deprecated (Java 8 assertions are included in core Truth 1.4+) and is completely unused in `invoker/core` tests. 

By removing `truth-java8-extension` and keeping `com.google.truth:truth:1.4.5` untouched, we eliminate dead test dependencies while guaranteeing 100% offline mirror compatibility during automated release validation builds.