### PR TITLE
ci: skip central-publishing upload during internal CI validation builds

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -106,6 +106,8 @@ mvn clean deploy -B \
   -P sonatype-oss-release \
   --settings=../settings.xml \
   -DaltDeploymentRepository=exit-gate-ar::https://us-maven.pkg.dev/oss-exit-gate-prod/ff-releases--mavencentral \
+  -DskipPublishing=true \
+  -Dcentral.skipPublishing=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase="${GPG_PASSPHRASE}" \
   -Dgpg.homedir="${GNUPGHOME}"


### PR DESCRIPTION
During internal CI validation builds (`.kokoro/build.sh`), `mvn clean deploy -P sonatype-oss-release` failed during the deployment phase:
`Could not transfer artifact ... from/to sonatype-central-portal (https://central.sonatype.com/repository/maven-snapshots/): authentication failed ... status: 401 Unauthorized`

While `.kokoro/build.sh` specifies `-DaltDeploymentRepository` to stage validation artifacts in internal testing registries, `central-publishing-maven-plugin` (`<extensions>true</extensions>`) overrides default Maven deployment behavior and attempts an authenticated upload to public Sonatype Central.

By adding `-DskipPublishing=true` and `-Dcentral.skipPublishing=true` to `.kokoro/build.sh` (following standard open-source library CI patterns), we allow internal validation deployments (`altDeploymentRepository`) to complete cleanly without triggering public Sonatype authentication.