### PR TITLE
ci: copy artifacts from all module target folders for Kokoro attestation

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -119,4 +119,11 @@ ARTIFACTS_DIR="${REPO_DIR}/artifacts"
 mkdir -p "${ARTIFACTS_DIR}"
 
 # Copy target jars and poms (excluding test jars) to be captured by build.cfg
-find target/ -maxdepth 1 -name "*.jar" -o -name "*.pom" | grep -v "test" | xargs -I {} cp {} "${ARTIFACTS_DIR}/"
+# Copy target jars and poms from all module target/ folders across the package hierarchy,
+# while explicitly excluding unit test artifacts (test-classes/, *-tests.jar, *-test-sources.jar)
+find . -path "*/target/*" \
+  \( -name "*.jar" -o -name "*.pom" \) \
+  ! -path "*/test-classes/*" \
+  ! -name "*-tests.jar" \
+  ! -name "*-test-sources.jar" \
+  | xargs -r -I {} cp {} "${ARTIFACTS_DIR}/"


### PR DESCRIPTION
During multi-module CI validation builds (`invoker`), Kokoro attestation generation failed post-build:
`failed precondition no artifacts found for fileset artifacts, which is required;AppErrorCode=9`

While `mvn clean deploy` completed successfully (`BUILD SUCCESS`), `.kokoro/build.sh` used `find target/ -maxdepth 1` to copy built artifacts into `${REPO_DIR}/artifacts/` for attestation. In multi-module projects like `invoker`, built `.jar` and `.pom` files reside inside nested subdirectories (`core/target/`, `conformance/target/`, `testfunction/target/`), causing `find target/ -maxdepth 1` to return empty results.

By updating `.kokoro/build.sh` to search across all nested `target/` directories while explicitly excluding unit test artifacts (`! -path "*/test-classes/*" ! -name "*-tests.jar"`), all built production deliverables across single-module and multi-module packages are cleanly captured for Kokoro attestation.