### PR TITLE
ci: set ARTIFACTS_DIR to KOKORO_ARTIFACTS_DIR in build script for Kokoro attestation

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -115,7 +115,7 @@ mvn clean deploy -B \
 # ==============================================================================
 # 4. Copy artifacts to 'artifacts/' folder for Kokoro Attestation Generation
 # ==============================================================================
-ARTIFACTS_DIR="${REPO_DIR}/artifacts"
+ARTIFACTS_DIR="${KOKORO_ARTIFACTS_DIR}/artifacts"
 mkdir -p "${ARTIFACTS_DIR}"
 
 # Copy target jars and poms (excluding test jars) to be captured by build.cfg


### PR DESCRIPTION
During CI validation builds (`.kokoro/build.sh`), Kokoro attestation generation failed post-build:
`failed precondition no artifacts found for fileset artifacts, which is required;AppErrorCode=9`

While `.kokoro/build.sh` successfully copied built jars using `find` (`BUILD SUCCESS`), line 118 defined `ARTIFACTS_DIR` as `${REPO_DIR}/artifacts` (`/src/git/functions-framework-java/artifacts/`). When `.kokoro/build.cfg` (`artifact_globs: "artifacts/*"`) evaluated post-build relative to the container root `$KOKORO_ARTIFACTS_DIR` (`/src/artifacts/*`), no matching artifacts were found.

By setting `ARTIFACTS_DIR="${KOKORO_ARTIFACTS_DIR}/artifacts"`, built jars and poms are staged directly into the container root where `build.cfg` fileset globs expect them, enabling complete post-build attestation generation.