### PR TITLE
ci: temporarily set default manual build target to functions-framework-api

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -83,7 +83,7 @@ if [[ -n "${_LOUHI_REF_NAME:-}" ]]; then
     PACKAGE_DIR="invoker"
   else
     echo "Unknown tag format: ${_LOUHI_REF_NAME}. Defaulting to invoker."
-    PACKAGE_DIR="invoker"
+    PACKAGE_DIR="functions-framework-api"
   fi
 else
   # Fallback for manual/non-tag builds (e.g. testing)
@@ -93,7 +93,7 @@ else
   elif [[ $KOKORO_JOB_NAME == *"functions-framework-api"* ]]; then
     PACKAGE_DIR="functions-framework-api"
   else
-    PACKAGE_DIR="invoker"
+    PACKAGE_DIR="functions-framework-api"
   fi
 fi
 


### PR DESCRIPTION
During manual CI release execution on `main`, the build script defaults to `PACKAGE_DIR="invoker"` when no explicit release tag is present in the job environment.

To stage `functions-framework-api` (`v2.0.2`) artifacts directly into the release registry via a manual execution, this change temporarily sets the fallback target directory to `functions-framework-api`. 

Once the API module artifacts are published, the fallback target will be reverted back to `invoker` prior to releasing downstream modules.