### PR TITLE
build: remove legacy central-publishing-maven-plugin in favor of staging deployment

### DIFF
--- a/function-maven-plugin/pom.xml
+++ b/function-maven-plugin/pom.xml
@@ -230,23 +230,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.10.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>sonatype-central-portal</publishingServerId>
-              <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
-              </dependency>
-            </dependencies>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/functions-framework-api/pom.xml
+++ b/functions-framework-api/pom.xml
@@ -259,23 +259,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.10.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>sonatype-central-portal</publishingServerId>
-              <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
-              </dependency>
-            </dependencies>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/invoker/pom.xml
+++ b/invoker/pom.xml
@@ -198,23 +198,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.10.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>sonatype-central-portal</publishingServerId>
-              <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
-              </dependency>
-            </dependencies>
-          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
With the migration to staging-based release verification (`-DaltDeploymentRepository`), retaining `central-publishing-maven-plugin` (`extensions=true`) inside project POMs caused deployment conflicts and `NullPointerException` errors (`Server.clone() because server is null`) when building non-snapshot release versions (`v2.0.2`).

This cleanup removes the legacy direct-publishing plugin from all project modules, allowing standard `maven-deploy-plugin` to cleanly stage GPG-signed release artifacts directly into the staging repository for automated promotion and verification.