### PR TITLE
ci: revert default manual build target back to invoker

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -83,7 +83,7 @@ if [[ -n "${_LOUHI_REF_NAME:-}" ]]; then
     PACKAGE_DIR="invoker"
   else
     echo "Unknown tag format: ${_LOUHI_REF_NAME}. Defaulting to invoker."
-    PACKAGE_DIR="functions-framework-api"
+    PACKAGE_DIR="invoker"
   fi
 else
   # Fallback for manual/non-tag builds (e.g. testing)
@@ -93,7 +93,7 @@ else
   elif [[ $KOKORO_JOB_NAME == *"functions-framework-api"* ]]; then
     PACKAGE_DIR="functions-framework-api"
   else
-    PACKAGE_DIR="functions-framework-api"
+    PACKAGE_DIR="invoker"
   fi
 fi
 


### PR DESCRIPTION
Now that `functions-framework-api` (`v2.0.2`) artifacts are published to the public artifact registry, the temporary fallback override introduced for initial release testing is no longer required.

This change reverts the default fallback target directory in CI release scripts back to `invoker` prior to releasing downstream modules.

Change-Id: Ife667255b3e6d4f36bbfa866f3a10e1b9e014065