### PR TITLE
ci: prioritize release tag name and changed files for package detection

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,25 +72,27 @@ gpg --batch --import "${GPG_KEYRING}"
 # ==============================================================================
 # 3. Build, Sign, and Deploy
 # ==============================================================================
-# Detect which package to build based on the Louhi trigger tag
-if [[ -n "${_LOUHI_REF_NAME:-}" ]]; then
-  echo "Triggered by Louhi tag: ${_LOUHI_REF_NAME}"
-  if [[ "${_LOUHI_REF_NAME}" == *functions-framework-api* ]]; then
+# Detect which package to build based on Louhi tag or changed files
+TAG_NAME="${_LOUHI_TAG_NAME:-${_LOUHI_REF_NAME:-}}"
+
+if [[ -n "${TAG_NAME}" && "${TAG_NAME}" != "main" && "${TAG_NAME}" != "master" ]]; then
+  echo "Detected release tag: ${TAG_NAME}"
+  if [[ "${TAG_NAME}" == *functions-framework-api* ]]; then
     PACKAGE_DIR="functions-framework-api"
-  elif [[ "${_LOUHI_REF_NAME}" == *function-maven-plugin* ]]; then
+  elif [[ "${TAG_NAME}" == *function-maven-plugin* ]]; then
     PACKAGE_DIR="function-maven-plugin"
-  elif [[ "${_LOUHI_REF_NAME}" == *java-function-invoker* ]]; then
+  elif [[ "${TAG_NAME}" == *java-function-invoker* ]]; then
     PACKAGE_DIR="invoker"
   else
-    echo "Unknown tag format: ${_LOUHI_REF_NAME}. Defaulting to invoker."
+    echo "Unknown tag format: ${TAG_NAME}. Defaulting to invoker."
     PACKAGE_DIR="invoker"
   fi
 else
-  # Fallback for manual/non-tag builds (e.g. testing)
-  echo "No Louhi tag detected. Falling back to KOKORO_JOB_NAME detection."
-  if [[ $KOKORO_JOB_NAME == *"function-maven-plugin"* ]]; then
+  # Fallback: inspect changed files in release commit (_LOUHI_CHANGED_FILES)
+  echo "No specific release tag detected. Inspecting _LOUHI_CHANGED_FILES: ${_LOUHI_CHANGED_FILES:-}"
+  if [[ "${_LOUHI_CHANGED_FILES:-}" == *function-maven-plugin* ]]; then
     PACKAGE_DIR="function-maven-plugin"
-  elif [[ $KOKORO_JOB_NAME == *"functions-framework-api"* ]]; then
+  elif [[ "${_LOUHI_CHANGED_FILES:-}" == *functions-framework-api* ]]; then
     PACKAGE_DIR="functions-framework-api"
   else
     PACKAGE_DIR="invoker"


### PR DESCRIPTION
Update package directory detection in release build script to prioritize `_LOUHI_TAG_NAME` over `_LOUHI_REF_NAME`, and fallback to inspecting `_LOUHI_CHANGED_FILES`.

During automated release tag triggers, `_LOUHI_TAG_NAME` contains the release tag string (e.g. `function-maven-plugin-v1.0.2`), whereas `_LOUHI_REF_NAME` defaults to the target branch name (`main`). Inspecting `_LOUHI_TAG_NAME` first and checking `_LOUHI_CHANGED_FILES` for fallback ensures that release builds correctly target their intended component directory.

Change-Id: I71ae86de8fcfce9e9a030d0cb422b09906b239c2